### PR TITLE
Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,29 @@
-# Stan-dev design documents repo
-This is where we will start putting design documents and functional specs that attempt to describe major changes to our code base. We're taking heavy inspiration from the [Rust project's version](https://github.com/rust-lang/rfcs)
+# Stan Design Documents Repository
+
+This repository is where the Stan community puts design documents and functional specifications that describe major changes to our code base. These documents cover many aspects of the Stan ecosystem including the Stan language, interface changes, algorithms, and implementation details.
+
+We welcome proposals and discussion from everyone in the community.
+
+Our process for accepting proposals takes inspiration from [IETF Internet-Drafts](https://www.ietf.org/standards/ids/). We want the process to be lightweight and result in accepting documents that have consensus from the community at the time of approval.
+
+
+## Submit a Design Document
+
+Anyone can propose a design document. Please write a design document roughly following [the template](0000-template.md) and submit a pull request. The author of the specification has the flexibility to drive the process to getting the document approved. We suggest discussing the proposal in a pull request or on [Discourse](https://discourse.mc-stan.org).
+
+Design documents rarely go through the process unchanged, especially as alternatives and drawbacks are identified. Proposals can go through edits for months as we discuss major changes to Stan. Everyone in the community is welcome to make comments (relevant to the proposal). 
+
+Proposals are accepted and merged into this repository when there is consensus from the community. In practice, this means giving enough time for members of the community to review/comment/request changes on the proposal. Proposals can be accepted if at least one other (non-author) Stan developer endorses the final draft of the design document and there are no denials. 
+
+Stan Developers: please feel free to merge PRs into this repository when they have reached this point. Acceptance into this repository is non-binding; at the time of the merge, we, the community, think it's a good idea.
+
 
 # Design Review
 
 ## When is design necessary?
 
 Most changes can be implemented and reviewed via the [normal pull request workflow](https://github.com/stan-dev/math/wiki/Developer-Doc#pull-requests). Some changes are substantial enough that we ask that these be put through a design review for approval, similar to how an implementation is approved in a pull request.
+
 
 ## What is a design?
 
@@ -15,7 +33,6 @@ Once a functional spec has been agreed upon, we next need a design codified as a
 
 [This design](https://github.com/stan-dev/design-docs/blob/master/designs/0001-logger-io.md) has a functional spec in the first 5 or 6 pages and then a fairly detailed technical spec following, and should be used as an example.
 
-## Goals for design review
 
 For user-facing designs, we want to give them a lot of exposure to the world before we implement something, as we rarely take away features and want to maintain backwards compatibility for as long as possible (possibly forever). Once it's in, it's in, and this puts a high bar on new additions and we want to make sure everyone has a chance to look them over.
 
@@ -28,21 +45,20 @@ Design review ensures that the high level technical choices are simple, communic
 Designs and issues vary in a multitude of details concerning how they are staged.  A successful life cycle for a major issue might include:
 
 * a brainstorming session on Discourse where the underlying problem is raised and broad, preliminary ideas are proposed and discussed,
-* one or more developers turning these ideas into a design proposal, typically on a shared Wiki page,
-* one proposal by the relevant managing stakeholder,
+* one or more members of the community turning these ideas into a design proposal, typically on a shared Wiki page,
 * the accepted design and accompanying discussion being summarized and specified at greater detail a GitHub issue, which may host its own lower-level discussion of technical issues,
 * the design being implemented on a branch from the development branch of the relevant repositories with sufficient unit test coverage and documentation to release the feature,
 * a pull request being made for the issue and goes through normal code review on GitHub, returning to the previous step until it is approved through code review
 * the issue being merged into the development branches of the relevant repositories, which will include the feature in the next release.
 
-Once a design is accepted, it should not be substantially changed. Minor changes may be submitted as amendments.  This is one reason why it may not be productive to go into fine-grained implementation details in the technical specification.  An approved design does not assign anyone in particular to work on the design, but one should create an issue linking or incorporating the design document.
+An approved design does not assign anyone in particular to work on the design, but one should create an issue linking or incorporating the design document.
 
 ## What requires a design review?
 
 What exactly constitutes a truly major change is evolving based on community norms and varies depending on what part of the ecosystem you are proposing to change, but may include:
 semantic or syntactic changes to the language that is not a bugfix,
 adding or removing language features,
-changing the interfaces among modules impacting multiple managing stakeholders, such as math, algorithms, services, and interfaces.
+changing the interfaces impacting multiple modules, such as math, algorithms, services, and interfaces.
 
 In general, thinking “oh, this might include a large refactor” or “this is really exciting” or “this might not work everywhere” are good indicators you should seek design approval.
 
@@ -55,19 +71,13 @@ bug fixes that touch only a few files.
 
 It is generally a good idea to pursue feedback from other project developers beforehand.  The easiest way to do this is in a Discourse post that brings up the problem or issue and perhaps a rough outline of proposed solution at a high level and solicits further ideas and brainstorming. As a rule of thumb, receiving encouraging feedback from longstanding project developers on such a thread is a good indication that the design or issue is worth pursuing.
 
-## The process
-
-Write a design document roughly following [the template](0000-template.md). Designs that do not present convincing motivation, demonstrate understanding of the impact of the design, or are disingenuous about the drawbacks or alternatives tend to be poorly received.
-Share it with the Stan core developers, advertising it on discourse and ideally the weekly meeting. Especially share it with one or more developers with design approval privileges.
-Designs rarely go through this process unchanged, especially as alternatives and drawbacks are illuminated. Edit the existing Google doc and allow it to preserve the history.
-Submit the design to a reviewer and work with them until it is accepted or postponed.
-
 ## Conducting design reviews
 
-Anyone involved may schedule meetings to discuss the design with interested parties over a video chat. It’s generally a good idea to get an approving stakeholder involved for at least one of these. A design may be postponed if we don’t want to evaluate the proposal immediately for reasons such as not being urgent or depending on other designs to be completed.  Postponing a design indicates that at least someone thinks we might reasonably consider making the change in the future---otherwise it would just be closed. To close a design request for comments, a reviewer should describe the reasoning in the relevant discourse post and lock the thread.
+Anyone involved may schedule meetings to discuss the design with interested parties over a video chat. A design may be postponed if we don’t want to evaluate the proposal immediately for reasons such as not being urgent or depending on other designs to be completed.  Postponing a design indicates that at least someone thinks we might reasonably consider making the change in the future---otherwise it would just be closed. To close a design request for comments, a reviewer should describe the reasoning in the relevant discourse post.
 
 If the motivation and the design are reasonably sound, a reviewer should interact with the proposer and community to give constructive feedback if the reviewer thinks the design could be accepted in the near term.
 
 ## Implementing an accepted design
 
 No one in particular is obligated to implement an accepted design.  There will be an associated issue in the relevant repository that keeps track of anyone working on it. If you see an accepted design and want to work on it, post in that issue and tag the relevant parties.
+


### PR DESCRIPTION
I'm following up on this conversation on Discourse:

https://discourse.mc-stan.org/t/process-for-design-docs/

I edited the README.md to reflect a few things:
- proposals are welcome from everyone
- comments are welcome from everyone
- the process is a work in progress
- we are taking inspiration from IETF Internet-Drafts (and removing the inspiration from Rust's RFC process)
- the concept is to build consensus
- tried to not be heavily rule-based
- made it clear when a proposal could be accepted and who accepts it.

If any of this is unclear or isn't accomplished, please point it out or suggest changes.
