### PR TITLE
Matrix autodiff type

### DIFF
--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -1,6 +1,6 @@
 - Feature Name: static_matrices
 - Start Date: April 30th, 2020
-- RFC PR: [Example Branch](https://github.com/stan-dev/math/compare/feature/var-template)
+- RFC PR: 
 - Stan Issue: [#1805](https://github.com/stan-dev/math/issues/1805)
 
 # Summary
@@ -360,8 +360,9 @@ would be decided the same way.
 The algorithm for figuring out the underlying matrix types for these variables
 is as follows:
 
-1. Define all user-defined functions only for `matvar` types, and all
-internally defined variables and returned variables are `matvar` types as well.
+1. Define all user-defined functions only for `matvar` types. Define all local
+variables in user-defined functions and all returned variables to have `matvar`
+types as well.
 
 2. Assume every named and unnamed matrix variable in the `parameters`,
 `transformed parameters` and `model` blocks use `varmat` types
@@ -375,7 +376,10 @@ variable.
 5. If a `matvar` matrix variable is assigned to a second matrix variable,
 the second is made to be a `matvar` variable.
 
-6. Repeat steps 3-6 until the types of every variable in the program do not
+6. If the result of a function is assigned to a `matvar` matrix variable,
+all the inputs to that function are made to be `matvar` as well.
+
+7. Repeat steps 3-6 until the types of every variable in the program do not
 change any more.
 
 It is already possible to determine, given function name and a set of argument

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -25,7 +25,7 @@ A[10, 10] = 5;
 
 Besides that they can be thought of as standard matrix.
 
-At the Stan Math level a `static_matrix` is a `var_type<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_type<Eigen::Matrix<double, -1, -1>>`\*. This means that accessors for the value and adjoint of `var_type` objects can access contiguous chunks of each part of the `var_type`. Any function that accept a `var_type<T>` will support static matrices.
+At the Stan Math level a `static_matrix` is a `var_type<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_type<Eigen::Matrix<double, -1, -1>>`*. This means that accessors for the value and adjoint of `var_type` objects can access contiguous chunks of each part of the `var_type`. Any function that accept a `var_type<T>` will support static matrices.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -56,10 +56,10 @@ More templates can be confusing and will lead to larger compile time. The confus
 With `sparse_matrix` and `complex_matrix` this will now add _another_ `*_matrix` type proposal to the language. There's no way to get around this in the Stan language currently, though some small side discussions exist to support attributes on types such as
 
 ```stan
-@(sparse, static)
+@(sparse_type, static_type) // can't have static here because of C++ keyword
 matrix[N, M] X;
 
-@(complex, static)
+@(complex_type, static_type)
 vector[N] Y;
 ```
 
@@ -92,4 +92,4 @@ I'm interested in hearing about Stan language semantics and any difficulties I m
 
 Any intricacies of using the GPU via `var_type<matrix_cl<double>>` should be deferred to a separate discussions or can happen during the implementation.
 
-\*Interestingly, this also means that `var_type<float>` and `var_type<long double>` can be legal.
+*Interestingly, this also means that `var_type<float>` and `var_type<long double>` can be legal.

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -6,23 +6,24 @@
 # Summary
 [summary]: #summary
 
-This proposes a generalization of the reverse mode autodiff type in Stan Math,
-`var_value<T>`, where `T` is the underlying storage type of the autodiff variable.
-For `T == double`, this type is equivalent to the current Stan Math `var` type.
+This proposes two things:
 
-The usefulness of this type comes from setting `T` to more general data structures,
-in particular the Eigen Matrix types. Instead of dealing with matrices of vars,
-this allows operations in the Math library to be written in terms of vars that are
-themselves matrices.
+1. A generalization of the C++ reverse mode autodiff type in Stan Math, from `stan::math::var`
+to `stan::math::var_value<T>`, where `T` is the underlying storage type of the autodiff
+variable. For `T == double`, this type is equivalent to the current Stan Math `var` type.
+The usefulness of the generalized reverse mode autodiff type comes from passing more
+general data structures as the template type, in particular the Eigen Matrix types.
 
-This makes working with matrix variables in Stan autodiff much faster. This design
-is fully backwards compatible with the curren Stan autodiff types and those remain.
+2. A design for exposing these autodiff variables at the Stan language level
 
-For the rest of this proposal, "autodiff" means "reverse mode autodiff".
+An autodiff type that allows customization of the underlying storage object makes it possible
+for matrices, instead of being data structures of autodiff types, for the autodiff type
+itself to represent a matrix. Operations on these new types can be more efficient than the old
+ones, and this design remains fully backwards compatible with the curren Stan autodiff types.
 
-With optimizations from the compiler the conditions for a `matrix` to be a
-constant matrix can be detected and applied to Stan programs automatically
-for users.
+For the rest of this proposal, "autodiff" means "reverse mode autodiff," and all C++ functions
+are assumed to reside in the `stan::math` namespace. The necessary namespace will be
+included if this is not true.
 
 # Motivation
 [motivation]: #motivation
@@ -32,55 +33,57 @@ a pointer to an underlying array of autodiff objects, each of those holding
 a pointer to the underlying autodiff object implementation.
 
 The basic Eigen type used by Stan is `Eigen::Matrix<var, R, C>`. For brevity,
-this will be referred to as a "matvar" type (a matrix of vars). There are no
-major differences between a matrix of vars or a vector of vars or a row vector
-of vars.
+this will be referred to as a `matvar` type (a matrix containing var variables).
+There are no major differences between a matrix of vars or a vector of vars or
+a row vector of vars.
 
 This proposal will enable an `N x M` Stan matrix to be defined in terms of one
 autodiff object with two separate `N x M` containers, one for its values and
 one for its adjoints.
 
 This basic example of this type is `var_value<Eigen::MatrixXd>`. For brevity,
-these will be referred to as "varmat" types (a var that is a matrix). Again,
+these will be referred to as `varmat` types (a var that contains a matrix). Again,
 there are no major differences when the matrix is replaced by a vector or a row vector.
 
-The motivation for introducing the varmat type is speed. These types speed up
+The motivation for introducing the `varmat` type is speed. These types speed up
 computations in a number of ways:
 
-1. The values in a varmat are stored separately from the `adjoints` and can
-be accessed independently. In a matvar the values and adjoints are interleaved.
-With how memory loads work on modern cpus, that means reading the values requires
-reading the values and the adjoints.
+1. The values in a `varmat` are stored separately from the `adjoints` and can
+be accessed independently. In a `matvar` the values and adjoints are interleaved
+With how caching and memory loads work on modern desktop CPUs, reading the values
+requires reading the values and the adjoints (reading an 8-byte double from memory
+loads data around it as well).
 
-2. To read all `N x M` values or adjoints of a varmat requires one pointer
-dereference and `N x M` double reads. Reading a similar matvar requires
+2. Reading all `N x M` values or adjoints of a `varmat` requires one pointer
+dereference and `N x M` double reads. Reading a similar `matvar` requires
 `N x M` pointer dereferences and `N x M` reads.
 
-3. Memory is linear in varmat, and in the best case interleaved in matvar
-(though because every element is a pointer, in worse case matvar memory accesses
-are entirely random).
+3. Memory is linear in `varmat`, and in the best case interleaved in `matvar`
+(though because every element is a pointer, in worse case `matvar` memory accesses
+are entirely random). The linear memory in `varmat` means that they can vectorized
+CPU instructions.
 
-4. Because values and adjoints of a varmat are each stored in one place, only
-two arena allocations are required to build an `N x M` matrix. matvar requires
-`N x M` allocations.
-
-5. varmat is a more suitable datastructure for autodiff variables on a GPU
-than matvar because the memory difficulties with pointer-chasing and strided
+4. `varmat` is a more suitable datastructure for autodiff variables on a GPU
+than `matvar` because the memory difficulties with pointer-chasing and strided
 accesses are more acute on GPUs than CPUs.
 
+5. Because values and adjoints of a `varmat` are each stored in one place, only
+two arena allocations are required to build an `N x M` matrix. `matvar` requires
+`N x M` allocations.
+
 See [here](https://github.com/stan-dev/design-docs/pull/21#issuecomment-625352581)
-for performance tests on a small subset of gradient evaluations using varmat and
-matvar types.
+for performance tests on a small subset of gradient evaluations using `varmat` and
+`matvar` types.
 
-matvar has two advantages that varmat does not duplicate. These are listed
-here to motivate the backwards compatibility of this proposal with matvar:
+`matvar` has two advantages that `varmat` does not duplicate. These are listed
+here to motivate the backwards compatibility of this proposal with `matvar`:
 
-1. matvar types are more compatible with existing Eigen code. For instance, it is possible
-to autodiff certain Eigen decompositions and solves with matvar types that will
-not work with varmat types.
+1. `matvar` types are more compatible with existing Eigen code. For instance, it is possible
+to autodiff certain Eigen decompositions and solves with `matvar` types that will
+not work with `varmat` types.
 
-2. It is easier to assign individual elements of a matvar to another variable -- this
-can be done by writing a new pointer over an old pointer. Assigning elements to a varmat
+2. It is easier to assign individual elements of a `matvar` to another variable -- this
+can be done by writing a new pointer over an old pointer. Assigning elements to a `varmat`
 can be done, but it requires either matrix copies (slow, and not implemented), or
 adding extra functions on the reverse pass callback stack (implemented and discussed later)
 
@@ -88,7 +91,8 @@ adding extra functions on the reverse pass callback stack (implemented and discu
 [math-implementation]: #math-implementation
 
 At this point versions of `var_value<T>` types have been implemented for `T` being an
-Eigen dense type, an Eigen sparse type, an Eigen expression, a double, or a GPU type.
+Eigen dense type, an Eigen sparse type, a limited number of Eigen expressions, a double,
+or a `matrix_cl`, a matrix with data stored on an OpenCL device (targetting GPUs).
 
 As var previously, `var_value<T>` is a PIMPL (pointer to implementation) type. The
 implementation of `var_value<T>` is held in `vari_value<T>`, and the only data a
@@ -99,8 +103,13 @@ The old `var` and `vari` types are now typdef aliases to `var_value<double>` and
 which is a new type used in the autodiff stacks (there are no changes there other than
 swapping `vari_base` in for `vari`).
 
-For implementation of `vari_value<T>` where `T` is an Eigen dense type (the basic varmat),
+For implementation of `vari_value<T>` where `T` is an Eigen dense type (the basic `varmat`),
 look [here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L604)
+
+For implementation of `vari_value<T>` where `T` is an Eigen expression, look
+[here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L546). The
+Eigen expressions implemented are ones that can be implemented as views into another matrix.
+So blocks of matrices, matrix transpose, column-wise access, etc. are supported.
 
 For implementation of `vari_value<T>` where `T = double` (the reimplementation of var),
 look [here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L81)
@@ -113,116 +122,119 @@ For implmementation of `vari_value<T>` where `T` is an Eigen sparse type, look
 
 ## Use and Testing in Functions
 
-Because varmat types are meant for performance, there are no default constructors
-for building matvar types from varmat or varmat from matvar (or any of the
-the varmat types above from any other). This is done on purpose to avoid implicit
+Because `varmat` types are meant for performance, there are no default constructors
+for building `matvar` types from `varmat` or `varmat` from `matvar` (or any of the
+the `varmat` types above from any other). This is done on purpose to avoid implicit
 conversions and any accidental slowdowns this may lead to. Everything written for
-varmat types is done explicitly, which makes it somewhat less automatic than
-matvar. The matvar types are still available for general purpose autodiff.
+`varmat` types is done explicitly, which makes it somewhat less automatic than
+`matvar`. The `matvar` types are still available for general purpose autodiff.
 
-Testing varmat autodiff types for different functions is done by including a
-`stan::test::test_ad_varmat(...)` mixed mode autodiff test along with every
+Testing `varmat` autodiff types for different functions is done by including a
+`stan::test::test_ad_`varmat`(...)` mixed mode autodiff test along with every
 `stan::test::test_ad(...)` test. The tests for `log_determinant`, available
 [here](https://github.com/stan-dev/math/blob/develop/test/unit/math/mix/fun/log_determinant_test.cpp)
 are typical of what is done.
 
-`test_ad_varmat` checks that the values and Jacobian of a function autodiff'd with
-varmat and matvar types behaves the same (and also that the functions throw
-errors in the same places). `test_ad_varmat` is not included by default in `test_ad`
-because not all functions support varmat autodiff.
+`test_ad_`varmat`` checks that the values and Jacobian of a function autodiff'd with
+`varmat` and `matvar` types behaves the same (and also that the functions throw
+errors in the same places). `test_ad_`varmat`` is not included by default in `test_ad`
+because not all functions support `varmat` autodiff.
 
-`test_ad_varmat` also checks return type conventions. For performance, it is assume
-a function takes in a mix of varmat and matvar types should also return a varmat.
+`test_ad_`varmat`` also checks return type conventions. For performance, it is assume
+a function takes in a mix of `varmat` and `matvar` types should also return a `varmat`.
 
-A complete list of varmat functions is planned to be developed for the compiler
-implementation. As an incomplete substitute, a list of functions with reverse mode
-implementations that are being converted to work with varmat is here:
+A complete list of `varmat` functions is planned for the compiler implementation.
+As an incomplete substitute, a list of functions with reverse mode implementations
+that are being converted to work with `varmat` is here:
 https://github.com/stan-dev/math/issues/2101 . A pull request
 ([here](https://github.com/stan-dev/math/pull/2214)) is up that adds support for
-varmat to all the non-multivariate distribution functions.
+`varmat` to all the non-multivariate distribution functions.
 
-## Assigning a varmat
+## Assigning a `varmat`
 
-Something in the original design doc that is not necessary anymore is the limitation
-that subsets of varmat variables cannot be assigned efficiently.
+A limitation from the original design doc that is no longer necessary is the limitation
+that subsets of `varmat` variables cannot be assigned efficiently.
 
 The efficiency loss was so great in the original design (requiring a copy of the entire
-varmat) that this idea was discarded completely.
+`varmat`) that this idea was discarded completely.
 
-There is a strategy available now to assign to subsets of varmat variables that is
+There is a strategy available now to assign to subsets of `varmat` variables that is
 more efficient than this.
 
-The idea is that when part of a varmat is assigned to, the values in that part of the
-varmat are saved into the memory arena before being overwritten, and a call is pushed
+The idea is that when part of a `varmat` is assigned to, the values in that part of the
+`varmat` are saved into the memory arena before being overwritten, and a call is pushed
 onto the chaining stack that will restore the values back from the arena and set the
-respective adjoints of the varmat entries to zero.
+respective adjoints of the `varmat` entries to zero.
 
-The assumptions that makes this work is after a subset of a varmat is overwritten,
-that part of the varmat cannot be used in any further calculations, and so the adjoints
+The assumptions that makes this work is after a subset of a `varmat` is overwritten,
+that part of the `varmat` cannot be used in any further calculations, and so the adjoints
 of that part of the matrix will be zero in the reverse pass at the time of assignment.
 
-This means that assignment into a varmat would invalidate any views into that
-varmat's memory.
+This means that assignment into a `varmat` variable would make it so that views
+point into that part of the `varmat` variable's memory no longer point to the expected
+variables.
 
 # Stanc3 implementation
 [stanc3-implementation]: #stanc3-implementation
 
-The language implementation of varmat is yet undefined. It was left unresolved because
+The language implementation of `varmat` is yet undefined. It was left unresolved because
 enough was clear from the initial discussions of how to handle the Math implementation
 regardless of how the language was handled.
 
 At this point, the Math maturing to the point that it is possible to compile a model using
-varmats values with a development version of the Stanc3 compiler (available
+`varmat`s values with a development version of the Stanc3 compiler (available
 [here](https://github.com/stan-dev/stanc3/pull/755), though it may take some effort to run since
 it is a work in progress). This Stanc3 compiler defines any variable with a name ending in
-`_varmat` to use a varmat type.
+`_`varmat`` to use a `varmat` type.
 
 A basic bernoulli MRP model with five population level covariates and seven group terms is available
-[here](https://github.com/bbbales2/computations_in_glms/blob/master/benchmark_model/mrp_varmat.stan).
+[here](https://github.com/bbbales2/computations_in_glms/blob/master/benchmark_model/mrp_`varmat`.stan).
 
-The initial varmat implementation of this model achieves a per-gradient speedup of around two.
+The initial `varmat` implementation of this model achieves a per-gradient speedup of around two.
 
-Now that varmat variables can be assigned, it is possible that the compiler silently replace every
-matvar in Stan with a varmat, and none of the standard Stan use cases would be affected.
+Now that `varmat` variables can be assigned, it is possible that the compiler silently replace every
+`matvar` in Stan with a `varmat`, and none of the standard Stan use cases would be affected.
 
 There are four major implementation strategies available at the Stanc3 level.
 
-1. Implement a new Stan type to differentiate explicitly between matvar and varmat types
+1. Implement a new Stan type to differentiate explicitly between `matvar` and `varmat` types
 
-2. Use matvar types whenever there is any function in the Stan program that does not support varmat
+2. Use `matvar` types for any function in the Stan program that does not support `varmat`
 
-3. Use varmat types by default, but if variable assignment is detected, or a varmat is used
-in an unsupported function convertion to and from matvar is used automatically.
+3. Use `varmat` types by default, but if variable assignment is detected, or a `varmat` is used
+in an unsupported function convert to and from `matvar` automatically.
 
-4. Use varmat types everywhere
+4. Use `varmat` types everywhere
 
 The original proposal was leaning towards #1 because it most naturally corresponds to the Math
-implementation. However, this leaves the problem of explicitly declaring varmat to the user. To
-avoid duplicating the user's manual and function reference for varmat and matvar functions, there
+implementation. However, this leaves the problem of explicitly declaring `varmat` to the user. To
+avoid duplicating the user's manual and function reference for `varmat` and `matvar` functions, there
 would also need to be some automatic, under the hood conversions between the types. This automatic
-converting would make it so that if a varmat is forgotten anywhere, the entire program will be
+converting would make it so that if a `varmat` is forgotten anywhere, the entire program will be
 slowed down. This sort of explicit typing shouldn't be too much of a problem in development models
 or generated Stan code, but in large, user-written models this would be error prone to implement
 and maintain.
 
-The advantage of #2 is that it would allow programs that can be written using only varmat functions
-to be very fast (and not even worry about any conversion to matvar or not). The problem with this
+The advantage of #2 is that it would allow programs that can be written using only `varmat` functions
+to be very fast (and not even worry about any conversion to `matvar` or not). The problem with this
 implementation is that, the difference between `varmat` and `matvar` would again need documented
 at the user level and some notation would need added to the user manual to indicate if a function
 is or is not available for optimization.
 
-The advantage of #3 is that varmat and matvar types could be implemented without any extra
-documentation for the user. Similarly to #2, if the user uses functions only available for matvar,
-there will be some slowdown as conversions between varmat and matvar are handled, but unlike #2
-the slowdown might not be catastrophic. In this case it would not be as crucial to carefully
-document the matvar and varmat types. varmat types would simply turn on when available and make
-the model faster when they were. The difficulty here is compiler implementation which would need
-to be more advanced to detect when it could use varmat and when it would need to convert to matvar.
+The advantage of #3, similarly to #2, is that `varmat` and `matvar` types could be handled
+automatically by the compiler. If the user requires functions only available for `matvar`,
+there will be some slowdown as conversions between `varmat` and `matvar` are handled. However,
+if the conversions are only used in relatively cheap parts of the computation, then the expensive
+parts of the calculation can still try to take advantage of `varmat` types. The difficulty here
+is compiler implementation which would need to be more advanced to detect when it could use
+`varmat` and when it would need to convert to `matvar`.
 
-The advantage of #4 is simplicitly of use and simplicitly of compiler implementation. If varmat
-types are used everywhere possible and there is no attempt to balance against the advantages of
-varmat against matvar, then the main difficulty will just be making sure to convert varmat
-to matvars and back again when used in functions that do not support varmat.
+The advantage of #4 is simplicitly of use and simplicitly of compiler implementation. If `varmat`
+types are used everywhere, and there is no attempt to balance against the advantages of
+`varmat` against `matvar`, then the main difficulty will just be making sure to convert `varmat`
+variables to `matvar` variables and back again when used in functions that do not support `varmat`.
+In the limit that all functions can be written to support `varmat`, then #2, #3, and #4 become
+equivalent.
 
 # Prior art
 [prior-art]: #prior-art

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -1,0 +1,95 @@
+- Feature Name: static_matrices
+- Start Date: April 30th, 2020
+- RFC PR: [Example Branch](https://github.com/stan-dev/math/compare/feature/var-template)
+- Stan Issue: [#1805](https://github.com/stan-dev/math/issues/1805)
+
+# Summary
+[summary]: #summary
+
+This proposes a `static_matrix` and `static_vector` type in the Stan language which on the backend will allow for significant performance opportunities. In Stan Math this will be represented by `var<Eigen::Matrix<double, 1, 1>>` or `var<matrix_cl<double>>`. The implementation will be fully backwards compatible with current Stan code. With optimizations from the compiler the conditions for a `matrix` to be a `static_matrix` can be detected and applied to Stan programs automatically for users.
+
+# Motivation
+[motivation]: #motivation
+
+Currently, a differentiable matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. Furthermore, because of the non-assignment condition the underlying matrix
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+At the language level, `static_matrix` can replace a `matrix` type if subsets of the matrix are never assigned to. That makes code such as the below illegal.
+
+```stan
+static_matrix[N, M] A = // Fill in A...
+A[10, 10] = 5;
+```
+
+Besides that they can be thought of as standard matrix.
+
+At the Stan Math level a `static_matrix` is a `var_type<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_type<Eigen::Matrix<double, -1, -1>>`\*. This means that accessors for the value and adjoint of `var_type` objects can access contiguous chunks of each part of the `var_type`. Any function that accept a `var_type<T>` will support static matrices.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This feature will be added in the following stages.
+
+1. Replace `var` and `vari` with templated types. See the [example branch](https://github.com/stan-dev/math/compare/feature/var-template) here to see how this will be done. `var` and `vari` have been changed to `var_type<T>` and `vari_type<T>` with aliases for the current methods as `using var = var_type<double>` and `using vari = vari_type<double>`. These aliases allow for full backwards compatibility with existing upstream dependencies.
+
+2. Make the stack allocator conform to accept `vari_type<T>` objects.
+
+3. Additional PRs for the current arithmetic operators for `var` to accept `vari_type<T>` object types.
+
+4. Sort out and add any additional specialized methods for static matrix types such as `cholesky_decompose`.
+
+5. Add the `static_matrix` and `static_vector` types to the Stan language along with supported signatures.
+
+6. Support detection and substitution of `matrix` types for `static_matrix` types.
+
+7. ???
+
+8. Done!
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+More templates can be confusing and will lead to larger compile time. The confusion of templates can be mitigated by proper duty of care with documentation and guides for the Stan Math type system. Larger compile times can't be avoided with this implementation, though other forthcoming proposals can allow us to monitor increases in compilation times.
+
+With `sparse_matrix` and `complex_matrix` this will now add _another_ `*_matrix` type proposal to the language. There's no way to get around this in the Stan language currently, though some small side discussions exist to support attributes on types such as
+
+```stan
+@(sparse, static)
+matrix[N, M] X;
+
+@(complex, static)
+vector[N] Y;
+```
+
+though this is far down the line for now.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+Besides the tech burden I'm rather happy with this implementation, though I'm open to any criticisms/alternatives and will add them here. You can see some of the discussion on this as well in issue [#1805](https://github.com/stan-dev/math/issues/1805) and the prior art below.
+
+# Prior art
+[prior-art]: #prior-art
+
+Discussions:
+ - [Efficient `static_matrix` type?](https://discourse.mc-stan.org/t/efficient-static-matrix-type/2136)
+ - [Static/immutable matrices w. comprehensions](https://discourse.mc-stan.org/t/static-immutable-matrices-w-comprehensions/12641)
+ - [Stan SIMD and Performance](https://discourse.mc-stan.org/t/stan-simd-performance/10488/11)
+ - [A New Continuation Based Autodiff By Refactoring](https://discourse.mc-stan.org/t/a-new-continuation-based-autodiff-by-refactoring/5037/2)
+
+[Enoki](https://github.com/mitsuba-renderer/enoki) is a very nice C++17 library for automatic differentiation which under the hood can transform their autodiff type from an arrays of structs to structs of arrays. It's pretty neat! Though implementing something like their methods would require some very large changes to the way we handle automatic differentiation.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+
+I'm interested in hearing about Stan language semantics and any difficulties I may have missed during the implementation section.
+
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+Any intricacies of using the GPU via `var_type<matrix_cl<double>>` should be deferred to a separate discussions or can happen during the implementation.
+
+\*Interestingly, this also means that `var_type<float>` and `var_type<long double>` can be legal.

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -11,7 +11,7 @@ This proposes a `static_matrix` and `static_vector` type in the Stan language wh
 # Motivation
 [motivation]: #motivation
 
-Currently, a differentiable matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. Furthermore, because of the non-assignment condition the underlying matrix
+Currently, a differentiable matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. 
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -198,7 +198,7 @@ The initial `varmat` implementation of this model achieves a per-gradient speedu
 Now that `varmat` variables can be assigned, it is possible that the compiler silently replace every
 `matvar` in Stan with a `varmat`, and none of the standard Stan use cases would be affected.
 
-There are four major implementation strategies available at the Stanc3 level.
+There are at least three major implementation strategies available at the Stanc3 level.
 
 1. Implement a new Stan type to let the user choose explicitly between `matvar` and `varmat` types
 
@@ -207,7 +207,8 @@ There are four major implementation strategies available at the Stanc3 level.
 3. Use `varmat` types by default, but if variable assignment is detected, or a `varmat` is used
 in an unsupported function convert to and from `matvar` automatically.
 
-4. Use `varmat` types everywhere
+This list is not exhaustive, and if there are other attractive language implementation options,
+it can be revised.
 
 The original proposal was leaning towards #1 because it most naturally corresponds to the Math
 implementation. However, this leaves the problem of explicitly declaring `varmat` to the user. This
@@ -232,11 +233,7 @@ parts of the calculation can still try to take advantage of `varmat` types. The 
 is compiler implementation which would need to be more advanced to detect when it could use
 `varmat` and when it would need to convert to `matvar`.
 
-The advantage of #4 is simplicitly of use and simplicitly of compiler implementation. If `varmat`
-types are used everywhere, and there is no attempt to balance against the advantages of
-`varmat` against `matvar`, then the main difficulty will just be making sure to convert `varmat`
-variables to `matvar` variables and back again when used in functions that do not support `varmat`.
-In the limit that all functions can be written to support `varmat`, then #2, #3, and #4 become
+In the limit that all functions can be written to support `varmat`, then #2 and #3 become
 equivalent.
 
 # Prior art

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -6,151 +6,223 @@
 # Summary
 [summary]: #summary
 
-This proposes a constant matrix type in stan that will allow for significant performance opportunities. In Stan Math this will be represented by `var_value<Eigen::Matrix<double, R, C>>` or `var_value<matrix_cl<double>>`. The implementation will be fully backwards compatible with current Stan code. With optimizations from the compiler the conditions for a `matrix` to be a constant matrix can be detected and applied to Stan programs automatically for users. The implementation of this proposal suggests a staged approach where a stan language level feature is delayed until type attributes are allowed in the language and constant matrices have support for the same set of methods that the current `matrix` type has.
+This proposes a generalization of the reverse mode autodiff type in Stan Math,
+`var_value<T>`, where `T` is the underlying storage type of the autodiff variable.
+For `T == double`, this type is equivalent to the current Stan Math `var` type.
+
+The usefulness of this type comes from setting `T` to more general data structures,
+in particular the Eigen Matrix types. Instead of dealing with matrices of vars,
+this allows operations in the Math library to be written in terms of vars that are
+themselves matrices.
+
+This makes working with matrix variables in Stan autodiff much faster. This design
+is fully backwards compatible with the curren Stan autodiff types and those remain.
+
+For the rest of this proposal, "autodiff" means "reverse mode autodiff".
+
+With optimizations from the compiler the conditions for a `matrix` to be a
+constant matrix can be detected and applied to Stan programs automatically
+for users.
 
 # Motivation
 [motivation]: #motivation
 
-Currently, an `NxM` matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. See [here](https://github.com/stan-dev/design-docs/pull/21#issuecomment-625352581) for performance tests on a small subset of gradient evaluations using matrices vs. constant matrices.
+Currently, an `N x M` matrix in Stan is represented as an Eigen matrix holding
+a pointer to an underlying array of autodiff objects, each of those holding
+a pointer to the underlying autodiff object implementation.
 
-# Guide-level explanation
-[guide-level-explanation]: #guide-level-explanation
+The basic Eigen type used by Stan is `Eigen::Matrix<var, R, C>`. For brevity,
+this will be referred to as a "matvar" type (a matrix of vars). There are no
+major differences between a matrix of vars or a vector of vars or a row vector
+of vars.
 
-At the Stan Math level a constant matrix is a `var_value<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_value<Eigen::Matrix<double, -1, -1>>`\*.  The value and adjoint of the matrix are stored separately in memory pointed to by the `vari_value`. Functions that currently support `Eigen::Matrix<var, R, C>` types will be extended to support `var_value<Eigen>` types
+This proposal will enable an `N x M` Stan matrix to be defined in terms of one
+autodiff object with two separate `N x M` containers, one for its values and
+one for its adjoints.
 
-At compiler level, a `matrix` can be substituted for a constant matrix if the matrix is only constructed once and it's subslices are never assigned to.
+This basic example of this type is `var_value<Eigen::MatrixXd>`. For brevity,
+these will be referred to as "varmat" types (a var that is a matrix). Again,
+there are no major differences when the matrix is replaced by a vector or a row vector.
 
-```stan
-matrix[N, M] A = // Construct matrix A...
-A[10, 10] = 5; // Will be dynamic!
-A[1:10, ] = 5; // Will be dynamic!
-A[, 1:10] = 5; // Will be dynamic!
-A[1:10, 1:10] = 5; // Will be dynamic!
-```
+The motivation for introducing the varmat type is speed. These types speed up
+computations in a number of ways:
 
-However extracting subslices from a matrix will still allow it to be constant.
+1. The values in a varmat are stored separately from the `adjoints` and can
+be accessed independently. In a matvar the values and adjoints are interleaved.
+With how memory loads work on modern cpus, that means reading the values requires
+reading the values and the adjoints.
 
-```stan
-matrix[N, M] A = // Construct matrix A...
-real b = A[10, 10]; // Will be real
-matrix[10, M] C = A[1:10, ]; // Will be static!
-row_vector[10] D = A[, 1:10]; // Will be static!
-matrix[10, 10] F = A[1:10, 1:10]; // Will be static!
-```
+2. To read all `N x M` values or adjoints of a varmat requires one pointer
+dereference and `N x M` double reads. Reading a similar matvar requires
+`N x M` pointer dereferences and `N x M` reads.
 
-Any function or operation in the Stan language that can accepts a `matrix` as an argument can also accept a constant matrix. Functions which can take in multiple matrices will only return a constant matrix if all of the other matrix inputs as well as the return type are static matrices.
+3. Memory is linear in varmat, and in the best case interleaved in matvar
+(though because every element is a pointer, in worse case matvar memory accesses
+are entirely random).
 
+4. Because values and adjoints of a varmat are each stored in one place, only
+two arena allocations are required to build an `N x M` matrix. matvar requires
+`N x M` allocations.
 
-# Reference-level explanation
-[reference-level-explanation]: #reference-level-explanation
+5. varmat is a more suitable datastructure for autodiff variables on a GPU
+than matvar because the memory difficulties with pointer-chasing and strided
+accesses are more acute on GPUs than CPUs.
 
-This feature will be added in the following stages.
+See [here](https://github.com/stan-dev/design-docs/pull/21#issuecomment-625352581)
+for performance tests on a small subset of gradient evaluations using varmat and
+matvar types.
 
-1. Replace `var` and `vari` with templated types.
-   - This has already been done in PR [#1915](https://github.com/stan-dev/math/pull/1915). `var` and `vari` have been changed to `var_value<T>` and `vari_value<T>` with aliases for the current methods as `using var = var_value<double>` and `using vari = vari_value<double>`. These aliases allow for full backwards compatibility with existing upstream dependencies.
+matvar has two advantages that varmat does not duplicate. These are listed
+here to motivate the backwards compatibility of this proposal with matvar:
 
-2. Add `var_value` and `vari_value` Eigen specializations
-   - This has been done in PR [#1952](https://github.com/stan-dev/math/pull/1952)
-   - The `vari_value` specialized for Eigen types holds two pointers of scalar arrays `val_mem_` and `adj_mem_` which are then accessed through `Eigen::Map` types `val_` and `adj_`.
+1. matvar types are more compatible with existing Eigen code. For instance, it is possible
+to autodiff certain Eigen decompositions and solves with matvar types that will
+not work with varmat types.
 
-3. Update `adj_jac_apply` to work with constant matrices.
-   - An example of this exists in [#1928](https://github.com/stan-dev/math/pull/1928). Using `adj_jac_apply` will provide a standardized and efficient API for adding new reverse mode functions for constant matrices.
+2. It is easier to assign individual elements of a matvar to another variable -- this
+can be done by writing a new pointer over an old pointer. Assigning elements to a varmat
+can be done, but it requires either matrix copies (slow, and not implemented), or
+adding extra functions on the reverse pass callback stack (implemented and discussed later)
 
-4. Additional PRs for the current arithmetic operators for `var` to accept `var_value<Eigen>` types.
-   - Since the new operations work on matrix types, `chain()` methods of the current operators will need to be specialized for matrix, vector, and scalar inputs.
+# Math Implementation
+[math-implementation]: #math-implementation
 
-4. Add additional specialized methods for constant matrices.
- - All of our current reverse mode specializations require an `Eigen::Matrix<var>`, which then assumes it needs to generate `N * M` `vari`. Specializations will need to be added for `var_type<Eigen::Matrix<T>>`
+At this point versions of `var_value<T>` types have been implemented for `T` being an
+Eigen dense type, an Eigen sparse type, an Eigen expression, a double, or a GPU type.
 
-5. Generalize the current autodiff testing framework to work with constant matrices.
+As var previously, `var_value<T>` is a PIMPL (pointer to implementation) type. The
+implementation of `var_value<T>` is held in `vari_value<T>`, and the only data a
+`var_value<T>` holders is a pointer to a `vari_value<T>` object.
 
-6. Add specializations for `operands_and_partials`, `scalar_seq_view`, `value_of` and other helper functions needed for the distributions.
+The old `var` and `vari` types are now typdef aliases to `var_value<double>` and
+`vari_value<double>` respectively. All `vari_value<T>` types inherit from `vari_base`,
+which is a new type used in the autodiff stacks (there are no changes there other than
+swapping `vari_base` in for `vari`).
 
-7. In the stanc3 compiler, support detection and substitution of `matrix/vector/row_vector` types for constant matrix types.
+For implementation of `vari_value<T>` where `T` is an Eigen dense type (the basic varmat),
+look [here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L604)
 
-Steps (1) and (2) have been completed in the example branch with some work done on (3). Step 7 has been chosen specifically to allow more time to discuss the stan language implementation. The compiler can perform an optimization step while parsing the stan program to see if a `matrix/vector/row_vector`:
+For implementation of `vari_value<T>` where `T = double` (the reimplementation of var),
+look [here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L81)
 
-1. Does not perform assignment after the first declaration.
-2. Uses methods that have constant matrix implementations in stan math.
+For implementation of `vari_value<T>` where `T` is an OpenCL type, look
+[here](https://github.com/stan-dev/math/blob/develop/stan/math/opencl/rev/vari.hpp#L23)
 
-and then replace `Eigen::Matrix<var, R, C>` with `var_value<Eigen::Matrix<double, R, C>>`.
+For implmementation of `vari_value<T>` where `T` is an Eigen sparse type, look
+[here](https://github.com/stan-dev/math/blob/develop/stan/math/rev/core/vari.hpp#L746)
 
-As an example of when the compiler could detect a constant matrix substitution, brms will normally output code for hierarchical models such as
+## Use and Testing in Functions
 
-```stan
-parameters {
-  vector[Kc] b;  // population-level effects
-  // temporary intercept for centered predictors
-  real Intercept;
-  real<lower=0> sigma;  // residual SD
-  vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  matrix[M_1, N_1] z_1;  // standardized group-level effects
-  // cholesky factor of correlation matrix
-  cholesky_factor_corr[M_1] L_1;
-}
-transformed parameters {
-  // actual group-level effects
-  matrix[N_1, M_1] r_1 = (diag_pre_multiply(sd_1, L_1) * z_1)';
-  // using vectors speeds up indexing in loops
-  vector[N_1] r_1_1 = r_1[, 1];
-  vector[N_1] r_1_2 = r_1[, 2];
-}
-model {
-  // initialize linear predictor term
-  vector[N] mu = Intercept + Xc * b;
-  for (n in 1:N) {
-    // add more terms to the linear predictor
-    mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
-  }
-  // more stuff
-```
+Because varmat types are meant for performance, there are no default constructors
+for building matvar types from varmat or varmat from matvar (or any of the
+the varmat types above from any other). This is done on purpose to avoid implicit
+conversions and any accidental slowdowns this may lead to. Everything written for
+varmat types is done explicitly, which makes it somewhat less automatic than
+matvar. The matvar types are still available for general purpose autodiff.
 
-This could be rewritten in brms to do the assignment of `mu` on one line. And because each `vector` and `matrix` do not perform assignment after the first declaration these would all be candidates to become constant matrices. With a type attribute of `const` in the language this would then look like:
+Testing varmat autodiff types for different functions is done by including a
+`stan::test::test_ad_varmat(...)` mixed mode autodiff test along with every
+`stan::test::test_ad(...)` test. The tests for `log_determinant`, available
+[here](https://github.com/stan-dev/math/blob/develop/test/unit/math/mix/fun/log_determinant_test.cpp)
+are typical of what is done.
 
-```stan
-parameters {
-  vector[Kc] b;  // population-level effects
-  // temporary intercept for centered predictors
-  real Intercept;
-  real<lower=0> sigma;  // residual SD
-  vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  matrix[M_1, N_1] z_1;  // standardized group-level effects
-  // cholesky factor of correlation matrix
-  cholesky_factor_corr[M_1] L_1;
-}
-transformed parameters {
-  // actual group-level effects
-  matrix[N_1, M_1] r_1 = (diag_pre_multiply(sd_1, L_1) * z_1)';
-  // using vectors speeds up indexing in loops
-  vector[N_1] r_1_1 = r_1[, 1];
-  vector[N_1] r_1_2 = r_1[, 2];
-}
-model {
-  // predictor terms
-  vector[N] mu = Intercept + Xc * b + r_1_1[J_1] .* Z_1_1 + r_1_2[J_1] * Z_1_2;
-  // more stuff
-```
+`test_ad_varmat` checks that the values and Jacobian of a function autodiff'd with
+varmat and matvar types behaves the same (and also that the functions throw
+errors in the same places). `test_ad_varmat` is not included by default in `test_ad`
+because not all functions support varmat autodiff.
 
+`test_ad_varmat` also checks return type conventions. For performance, it is assume
+a function takes in a mix of varmat and matvar types should also return a varmat.
 
-Delaying release of the `const` type to the language allows for a slow buildup of the needed methods. Once constant matrices have the same available methods as the `matrix/vector/row_vector` types we can release it as a stan language feature.
+A complete list of varmat functions is planned to be developed for the compiler
+implementation. As an incomplete substitute, a list of functions with reverse mode
+implementations that are being converted to work with varmat is here:
+https://github.com/stan-dev/math/issues/2101 . A pull request
+([here](https://github.com/stan-dev/math/pull/2214)) is up that adds support for
+varmat to all the non-multivariate distribution functions.
 
-# Drawbacks
-[drawbacks]: #drawbacks
+## Assigning a varmat
 
-More templates can be confusing and will lead to longer compile times. The confusion of templates can be mitigated by adding additional documentation and guides for the Stan Math type system. Larger compile times can't be avoided with this implementation, though other forthcoming proposals can allow us to monitor increases in compilation times.
+Something in the original design doc that is not necessary anymore is the limitation
+that subsets of varmat variables cannot be assigned efficiently.
 
-Waiting for type attributes in the Stan language means this feature will be a compiler optimization until both type attributes are allowed in the language and an agreement is made on stan language naming semantics. This is both a drawback and feature. While delaying a `constant_matrix` type as a user facing feature, it avoids the combinatorial problem that comes with additional type names for matrices proposed in the language such as `sparse` and `complex`.
+The efficiency loss was so great in the original design (requiring a copy of the entire
+varmat) that this idea was discarded completely.
 
-One large consideration is the need for the use of `flto` by compilers in order to not have a performance regression for ODE models because of missed divirtualization from the compiler. All vari created in stan are tracked and stored as pointers in our autodiff reverse mode tape `ChainableStack`. The underlying implementation of `ChainableStack` requires the use of an `std::vector` which is a homogeneous container. so all `vari_value<T>` must inherit from a `vari_base` that is then used as the type for the reverse mode tape in `ChainableStack` as a `std::vector<vari_base*>`. Because of the different underlying structures of each `vari_value<T>` the method `set_zero_adjoint()` of the `vari_value<T>` specializations must be `virtual` so that when calling the reverse pass over the tape via the `vari_base*` we call the proper `set_zero_adjoint()` member function for each type. But because Stan's autodiff tape is a global object, compilers will not devirtualize these function calls unless the compiler can optimize over the entire program (see [here](https://stackoverflow.com/questions/48906338/why-cant-gcc-devirtualize-this-function-call) for more info and a godbolt example).
+There is a strategy available now to assign to subsets of varmat variables that is
+more efficient than this.
 
-Multiple other methods were attempted such as
-1. boost::variants instead of polymorphism
-  - This still leads to a lookup from a function table which causes similar problems to the virtual table lookup
-2. A different stack for every vari_base subclass
-3.  Don't use the chaining stack for zeroing. Instead of having a chaining/non-chaining stack have a chaining/zeroing stack. Everything goes in the zeroing stack. Only chaining things go in the chaining stack.
-  - Both (2) and (3) also lead to performance problems because of having to allocate memory on multiple stacks
+The idea is that when part of a varmat is assigned to, the values in that part of the
+varmat are saved into the memory arena before being overwritten, and a call is pushed
+onto the chaining stack that will restore the values back from the arena and set the
+respective adjoints of the varmat entries to zero.
 
- The ODE models are particularly effected by this because of the multiple calls to `set_zero_adjoint()` that are used in the ODE solvers. This means that upstream packages will need to suggest (or automatically apply) the `-flto` flag to Stan programs so that these function calls can be devirtualized.
+The assumptions that makes this work is after a subset of a varmat is overwritten,
+that part of the varmat cannot be used in any further calculations, and so the adjoints
+of that part of the matrix will be zero in the reverse pass at the time of assignment.
+
+This means that assignment into a varmat would invalidate any views into that
+varmat's memory.
+
+# Stanc3 implementation
+[stanc3-implementation]: #stanc3-implementation
+
+The language implementation of varmat is yet undefined. It was left unresolved because
+enough was clear from the initial discussions of how to handle the Math implementation
+regardless of how the language was handled.
+
+At this point, the Math maturing to the point that it is possible to compile a model using
+varmats values with a development version of the Stanc3 compiler (available
+[here](https://github.com/stan-dev/stanc3/pull/755), though it may take some effort to run since
+it is a work in progress). This Stanc3 compiler defines any variable with a name ending in
+`_varmat` to use a varmat type.
+
+A basic bernoulli MRP model with five population level covariates and seven group terms is available
+[here](https://github.com/bbbales2/computations_in_glms/blob/master/benchmark_model/mrp_varmat.stan).
+
+The initial varmat implementation of this model achieves a per-gradient speedup of around two.
+
+Now that varmat variables can be assigned, it is possible that the compiler silently replace every
+matvar in Stan with a varmat, and none of the standard Stan use cases would be affected.
+
+There are four major implementation strategies available at the Stanc3 level.
+
+1. Implement a new Stan type to differentiate explicitly between matvar and varmat types
+
+2. Use matvar types whenever there is any function in the Stan program that does not support varmat
+
+3. Use varmat types by default, but if variable assignment is detected, or a varmat is used
+in an unsupported function convertion to and from matvar is used automatically.
+
+4. Use varmat types everywhere
+
+The original proposal was leaning towards #1 because it most naturally corresponds to the Math
+implementation. However, this leaves the problem of explicitly declaring varmat to the user. To
+avoid duplicating the user's manual and function reference for varmat and matvar functions, there
+would also need to be some automatic, under the hood conversions between the types. This automatic
+converting would make it so that if a varmat is forgotten anywhere, the entire program will be
+slowed down. This sort of explicit typing shouldn't be too much of a problem in development models
+or generated Stan code, but in large, user-written models this would be error prone to implement
+and maintain.
+
+The advantage of #2 is that it would allow programs that can be written using only varmat functions
+to be very fast (and not even worry about any conversion to matvar or not). The problem with this
+implementation is that, the difference between `varmat` and `matvar` would again need documented
+at the user level and some notation would need added to the user manual to indicate if a function
+is or is not available for optimization.
+
+The advantage of #3 is that varmat and matvar types could be implemented without any extra
+documentation for the user. Similarly to #2, if the user uses functions only available for matvar,
+there will be some slowdown as conversions between varmat and matvar are handled, but unlike #2
+the slowdown might not be catastrophic. In this case it would not be as crucial to carefully
+document the matvar and varmat types. varmat types would simply turn on when available and make
+the model faster when they were. The difficulty here is compiler implementation which would need
+to be more advanced to detect when it could use varmat and when it would need to convert to matvar.
+
+The advantage of #4 is simplicitly of use and simplicitly of compiler implementation. If varmat
+types are used everywhere possible and there is no attempt to balance against the advantages of
+varmat against matvar, then the main difficulty will just be making sure to convert varmat
+to matvars and back again when used in functions that do not support varmat.
 
 # Prior art
 [prior-art]: #prior-art
@@ -161,8 +233,8 @@ Discussions:
  - [Stan SIMD and Performance](https://discourse.mc-stan.org/t/stan-simd-performance/10488/11)
  - [A New Continuation Based Autodiff By Refactoring](https://discourse.mc-stan.org/t/a-new-continuation-based-autodiff-by-refactoring/5037/2)
 
-[JAX](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-In-Place-Updates) is an autodiff library developed by google whose array type has similar constraints to the constant matrix type proposed here.
+[JAX](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#%F0%9F%94%AA-In-Place-Updates) is an autodiff library developed by Google whose array type has similar constraints to the constant matrix type proposed here.
 
-[Enoki](https://github.com/mitsuba-renderer/enoki) is a very nice C++17 library for automatic differentiation which under the hood can transform their autodiff type from an arrays of structs to structs of arrays. It's pretty neat! Though implementing something like their methods would require some very large changes to the way we handle automatic differentiation.
+[Enoki](https://github.com/mitsuba-renderer/enoki) is a very nice C++17 library for automatic differentiation which under the hood can transform their autodiff type from an arrays of structs to structs of arrays.
 
-*Interestingly, this also means that `var_value<float>` and `var_value<long double>` can be legal.
+[FastAD](https://github.com/JamesYang007/FastAD) very fast C++ autodiff taking advantage of expressions, matrix autodiff types, and a static execution graph.

--- a/designs/0005-static-matrices.md
+++ b/designs/0005-static-matrices.md
@@ -6,69 +6,129 @@
 # Summary
 [summary]: #summary
 
-This proposes a `static_matrix` and `static_vector` type in the Stan language which on the backend will allow for significant performance opportunities. In Stan Math this will be represented by `var<Eigen::Matrix<double, 1, 1>>` or `var<matrix_cl<double>>`. The implementation will be fully backwards compatible with current Stan code. With optimizations from the compiler the conditions for a `matrix` to be a `static_matrix` can be detected and applied to Stan programs automatically for users.
+This proposes a constant matrix type in stan that will allow for significant performance opportunities. In Stan Math this will be represented by `var<Eigen::Matrix<double, R, C>>` or `var<matrix_cl<double>>`. The implementation will be fully backwards compatible with current Stan code. With optimizations from the compiler the conditions for a `matrix` to be a constant matrix can be detected and applied to Stan programs automatically for users. The implementation of this proposal suggests a staged approach where a stan language level feature is delayed until type attributes are allowed in the language and constant matrices have support for the same set of methods that the current `matrix` type has.
 
 # Motivation
 [motivation]: #motivation
 
-Currently, a differentiable matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. 
+Currently, a differentiable matrix in Stan is represented as an Eigen matrix holding a pointer to an underlying array of autodiff objects, each of those holding a pointer to the underlying autodiff object implementation. These `N*M` autodiff elements are expensive but necessary so the elements of a matrix can be assigned to without copying the entire matrix. However, in instances where the matrix is treated as a whole object such that underlying subsets of the matrix are never assigned to, we can store one autodiff object representing the entire matrix. See [here](https://github.com/stan-dev/design-docs/pull/21#issuecomment-625352581) for performance tests on a small subset of gradient evaluations using matrices vs. constant matrices.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-At the language level, `static_matrix` can replace a `matrix` type if subsets of the matrix are never assigned to. That makes code such as the below illegal.
+At the Stan Math level a constant matrix is a `var_value<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_value<Eigen::Matrix<double, -1, -1>>`\*.  This means that accessors for the value and adjoint of `var_value` objects can access contiguous chunks of each part of the `vari_value`. Any function that accepts a `var_value<T>` will support static matrices.
+
+At the language and level, a `matrix` can be substituted for a constant matrix if the matrix is only constructed once and never reassigned to.
 
 ```stan
-static_matrix[N, M] A = // Fill in A...
-A[10, 10] = 5;
+const matrix[N, M] A = // Construct matrix A...
+A[10, 10] = 5; // illegal!
+A[1:10, ] = 5; // illegal!
+A[, 1:10] = 5; // illegal!
+A[1:10, 1:10] = 5; // illegal!
+A = X; // illegal!
 ```
 
-Besides that they can be thought of as standard matrix.
+Any function or operation in the stan language that can accepts a `matrix` as an argument can also accept a constant matrix.
 
-At the Stan Math level a `static_matrix` is a `var_type<Eigen::Matrix<double, -1, -1>>` with an underlying pointer to a `vari_type<Eigen::Matrix<double, -1, -1>>`*. This means that accessors for the value and adjoint of `var_type` objects can access contiguous chunks of each part of the `var_type`. Any function that accept a `var_type<T>` will support static matrices.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
 This feature will be added in the following stages.
 
-1. Replace `var` and `vari` with templated types. See the [example branch](https://github.com/stan-dev/math/compare/feature/var-template) here to see how this will be done. `var` and `vari` have been changed to `var_type<T>` and `vari_type<T>` with aliases for the current methods as `using var = var_type<double>` and `using vari = vari_type<double>`. These aliases allow for full backwards compatibility with existing upstream dependencies.
+1. Replace `var` and `vari` with templated types. This has already been done in the example branch [here](https://github.com/stan-dev/math/compare/feature/var-template) (see [here](https://github.com/stan-dev/math/blob/d2967fe2bf6e0d4729d67a714ef40d95d907b18b/stan/math/rev/core/vari.hpp) for the `vari_value` implementation and [here](https://github.com/stan-dev/math/blob/d2967fe2bf6e0d4729d67a714ef40d95d907b18b/stan/math/rev/core/var.hpp) for `var_value`). `var` and `vari` have been changed to `var_value<T>` and `vari_value<T>` with aliases for the current methods as `using var = var_value<double>` and `using vari = vari_value<double>`. These aliases allow for full backwards compatibility with existing upstream dependencies.
 
-2. Make the stack allocator conform to accept `vari_type<T>` objects.
+2. Make the stack allocator conform to accept `vari_value<T>` objects. This is done by having `vari_type<T>` inherit from a `vari_base` class and defining the [`ChainableStack`](https://github.com/stan-dev/math/blob/d2967fe2bf6e0d4729d67a714ef40d95d907b18b/stan/math/rev/core/chainablestack.hpp) as
 
-3. Additional PRs for the current arithmetic operators for `var` to accept `vari_type<T>` object types.
+```cpp
+using ChainableStack = AutodiffStackSingleton<vari_base, chainable_alloc>;
+```
 
-4. Sort out and add any additional specialized methods for static matrix types such as `cholesky_decompose`.
+3. Additional PRs for the current arithmetic operators for `var` to accept `vari_value<T>` object types.
+   - Since the new operations work on matrix types, `chain()` methods of the current operators will need to be specialized for matrix, vector, and scalar inputs.
 
-5. Add the `static_matrix` and `static_vector` types to the Stan language along with supported signatures.
+4. Add additional specialized methods for constant matrices.
+ - All of our current reverse mode specializations require an `Eigen::Matrix<var>`, which then assumes it needs to generate `N * M` `vari`. Specializations will need to be added for `var_type<Eigen::Matrix<var>>`
 
-6. Support detection and substitution of `matrix` types for `static_matrix` types.
+5. In the stanc3 compiler, support detection and substitution of `matrix/vector/row_vector` types for constant matrix types.
 
-7. ???
+6. Create a design document for allowing type attributes in the stan language.
 
-8. Done!
+7. Add a `const` type attribute to the stan language.
+
+Steps (1) and (2) have been completed in the example branch with some work done on (3). Step (5-7) have been chosen specifically to allow more time to discuss the stan language implementation. The compiler can perform an optimization step while parsing the stan program to see if a `matrix/vector/row_vector`:
+
+1. Does not perform assignment after the first declaration.
+2. Uses methods that have constant matrix implementations in stan math.
+
+and then replace `Eigen::Matrix<var, R, C>` with `var_value<Eigen::Matrix<double, R, C>>`.
+
+As an example of when the compiler could detect a constant matrix substitution, brms will normally output code for hierarchical models such as
+
+```stan
+parameters {
+  vector[Kc] b;  // population-level effects
+  // temporary intercept for centered predictors
+  real Intercept;
+  real<lower=0> sigma;  // residual SD
+  vector<lower=0>[M_1] sd_1;  // group-level standard deviations
+  matrix[M_1, N_1] z_1;  // standardized group-level effects
+  // cholesky factor of correlation matrix
+  cholesky_factor_corr[M_1] L_1;
+}
+transformed parameters {
+  // actual group-level effects
+  matrix[N_1, M_1] r_1 = (diag_pre_multiply(sd_1, L_1) * z_1)';
+  // using vectors speeds up indexing in loops
+  vector[N_1] r_1_1 = r_1[, 1];
+  vector[N_1] r_1_2 = r_1[, 2];
+}
+model {
+  // initialize linear predictor term
+  vector[N] mu = Intercept + Xc * b;
+  for (n in 1:N) {
+    // add more terms to the linear predictor
+    mu[n] += r_1_1[J_1[n]] * Z_1_1[n] + r_1_2[J_1[n]] * Z_1_2[n];
+  }
+  // more stuff
+```
+
+This could be rewritten in brms to do the assignment of `mu` on one line. And because each `vector` and `matrix` do not perform assignment after the first declaration these would all be candidates to become constant matrices. With a type attribute of `const` in the language this would then look like:
+
+```stan
+parameters {
+  const vector[Kc] b;  // population-level effects
+  // temporary intercept for centered predictors
+  real Intercept;
+  real<lower=0> sigma;  // residual SD
+  const vector<lower=0>[M_1] sd_1;  // group-level standard deviations
+  const matrix[M_1, N_1] z_1;  // standardized group-level effects
+  // cholesky factor of correlation matrix
+  const cholesky_factor_corr[M_1] L_1;
+}
+transformed parameters {
+  // actual group-level effects
+  const matrix[N_1, M_1] r_1 = (diag_pre_multiply(sd_1, L_1) * z_1)';
+  // using vectors speeds up indexing in loops
+  const vector[N_1] r_1_1 = r_1[, 1];
+  const vector[N_1] r_1_2 = r_1[, 2];
+}
+model {
+  // predictor terms
+  const vector[N] mu = Intercept + Xc * b + r_1_1[J_1] .* Z_1_1 + r_1_2[J_1] * Z_1_2;
+  // more stuff
+```
+
+
+Delaying release of the `const` type to the language allows for a slow buildup of the needed methods. Once constant matrices have the same available methods as the `matrix/vector/row_vector` types we can release it as a stan language feature.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-More templates can be confusing and will lead to larger compile time. The confusion of templates can be mitigated by proper duty of care with documentation and guides for the Stan Math type system. Larger compile times can't be avoided with this implementation, though other forthcoming proposals can allow us to monitor increases in compilation times.
+More templates can be confusing and will lead to longer compile time. The confusion of templates can be mitigated by adding additional documentation and guides for the Stan Math type system. Larger compile times can't be avoided with this implementation, though other forthcoming proposals can allow us to monitor increases in compilation times.
 
-With `sparse_matrix` and `complex_matrix` this will now add _another_ `*_matrix` type proposal to the language. There's no way to get around this in the Stan language currently, though some small side discussions exist to support attributes on types such as
-
-```stan
-@(sparse_type, static_type) // can't have static here because of C++ keyword
-matrix[N, M] X;
-
-@(complex_type, static_type)
-vector[N] Y;
-```
-
-though this is far down the line for now.
-
-# Rationale and alternatives
-[rationale-and-alternatives]: #rationale-and-alternatives
-
-Besides the tech burden I'm rather happy with this implementation, though I'm open to any criticisms/alternatives and will add them here. You can see some of the discussion on this as well in issue [#1805](https://github.com/stan-dev/math/issues/1805) and the prior art below.
+Waiting for type attributes in the Stan language means this feature will be a compiler optimization until both type attributes are allowed in the language and an agreement is made on stan language naming semantics. This is both a drawback and feature. While delaying a `constant_matrix` type as a user facing feature, it avoids the combinatorial problem that comes with additional type names for matrices proposed in the language such as `sparse` and `complex` matrices.
 
 # Prior art
 [prior-art]: #prior-art
@@ -86,10 +146,14 @@ Discussions:
 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 
-I'm interested in hearing about Stan language semantics and any difficulties I may have missed during the implementation section.
+Whether the staged development process listed in the reference level explanation will suffice.
+
+If the restriction on not allowing assignment to the entire matrix such as `A = X` is too restrictive.
 
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-Any intricacies of using the GPU via `var_type<matrix_cl<double>>` should be deferred to a separate discussions or can happen during the implementation.
+Any intricacies of using the GPU via `var_value<matrix_cl<double>>` should be deferred to a separate discussions or can happen during the implementation.
 
-*Interestingly, this also means that `var_type<float>` and `var_type<long double>` can be legal.
+Methods involving changing the current `matrix` type in the Stan language
+
+*Interestingly, this also means that `var_value<float>` and `var_value<long double>` can be legal.


### PR DESCRIPTION
This is a new version of the design doc for a matrix autodiff type in Stan.

[Rendered version](https://github.com/stan-dev/design-docs/blob/static-matrix-dec-update/designs/0005-static-matrices.md)

(This is a follow up to the original pull [here](https://github.com/stan-dev/design-docs/pull/21))