### PR TITLE
Adjoint ode design

### DIFF
--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -349,10 +349,15 @@ simplifcation is made for usability reasons and the emprical
 observation that neither any CVODES example codes nor Julia's
 DifferentialEquations.jl package does facilitate a vector absolute
 tolerance for the backward quadrature integration. A user may work
-around this limitation by scaling the states and the parameters which
-will affect the order of the gradients accordingly and therefore
-change the tolerance checks of CVODES whenever a gradient approaches
-zero.
+around this limitation to some extent by scaling the states and the
+parameters which will affect the order of the gradients accordingly
+and therefore change the tolerance checks of CVODES whenever a
+gradient approaches zero. As the lack of the feature of a vector
+absolute tolerance for the parameter quadratures may potentially pose
+a limitation for future uses of the adjoint ODE solver, the
+implementation in stan-math should be written in an manner allowing
+for an inclusion of this feature at a later time (for example through
+an overload of the proposed signature).
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -208,14 +208,16 @@ Jacobian-vector products $\frac{df}{dy}\,v$, which we can compute
 directly using *forward mode*. In addition all 3 integration problems
 have their own relative and absolute tolerance targets.
 
-The propsed function should has the following signature:
+
+
+The proposed function should has the following signature:
 
 ```stan
-vector[] ode_adjoint(F f,
+vector[] ode_adjoint_tol_ctl(F f,
     vector y0,
     real t0, real[] times,
     real rel_tol_f, vector abs_tol_f,
-    real rel_tol_b, real abs_tol_b,
+    real rel_tol_b, vector abs_tol_b,
     real rel_tol_q, real abs_tol_q,
     int max_num_steps,
     int num_checkpoints,
@@ -234,7 +236,7 @@ The arguments are:
 6. ```abs_tol_f``` - Absolute tolerance vector for each state for
    forward solve (data)  
 7. ```rel_tol_b``` - Relative tolerance for backward solve (data)  
-8. ```abs_tol_b``` - Absolute tolerance for backward solve (data)  
+8. ```abs_tol_b``` - Absolute tolerance vector for each state backward solve (data)  
 9. ```rel_tol_q``` - Relative tolerance for backward quadrature (data)  
 10. ```abs_tol_q``` - Absolute tolerance for backward quadrature (data)  
 11. ```max_num_steps``` - Maximum number of timesteps to take in integrating
@@ -249,6 +251,37 @@ The arguments are:
 15. ```solver_b``` solver used for backward ODE problem: 1=Adams,
     2=bdf, 3=bdf_iterated  
 16. ```arg1, arg2, ...``` - Arguments passed unmodified to the ODE right
+hand side. The types ```T1, T2, ...``` can be any type, but they must match
+the types of the matching arguments of ```f```.
+
+In addition a function version is made available which mimics the
+existing ode interface for tolerances. This version will allow users
+to quickly try out the new adjoint interface. **The extra control
+parameters will be set based on best guesses as of now and are subject
+to change**:
+
+
+```stan
+vector[] ode_adjoint_tol(F f,
+    vector y0,
+    real t0, real[] times,
+    real rel_tol, real abs_tol,
+    int max_num_steps,
+    T1 arg1, T2 arg2, ...)
+```
+
+The arguments are:  
+1. ```f``` - User-defined right hand side of the ODE (`dy/dt = f`)  
+2. ```y0``` - Initial state of the ode solve (`y0 = y(t0)`)  
+3. ```t0``` - Initial time of the ode solve  
+4. ```times``` - Sorted arary of times to which the ode will be solved (each
+  element must be greater than t0)  
+5. ```rel_tol``` - Relative tolerance for all solves (data)  
+6. ```abs_tol``` - Absolute tolerance for all solves (data)  
+7. ```max_num_steps``` - Maximum number of timesteps to take in integrating
+  the ODE solution between output time points for forward and backward
+  solve (data)  
+8. ```arg1, arg2, ...``` - Arguments passed unmodified to the ODE right
 hand side. The types ```T1, T2, ...``` can be any type, but they must match
 the types of the matching arguments of ```f```.
 

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -107,31 +107,31 @@ phase.
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The ODE adjoint method for ODEs is relatively involved mathematically. The
-main challenge comes from a mix of different notation and conventions
-used in different fields. Here we relate commonly used notation within
-Stan math to the [user guide of
+The ODE adjoint method for ODEs is relatively involved
+mathematically. The main challenge comes from a mix of different
+notation and conventions used in different fields. Here we relate
+commonly used notation within Stan math to the [user guide of
 CVODES](https://computing.llnl.gov/sites/default/files/public/cvs_guide-5.6.1.pdf),
-the underlying library we employ to handle the numerical
-solution. The goal of reverse mode autodiff is to calculate the
-derivative of some function $l(\theta)$ wrt. to it's parameters
-$\theta$ at some particular realization of $\theta$; here $\theta$
-denotes a set of parameters. The function $l$
-now depends on the solution of an ODE given as initial value problem
+the underlying library we employ to handle the numerical solution. The
+goal of reverse mode autodiff is to calculate the derivative of some
+function $l(\theta)$ wrt. to it's parameters $\theta$ at some
+particular realization of $\theta$; here $\theta$ denotes a set of
+parameters. For example, the likelihood is defined as the normal log
+probability density for a single observation at time-point $T$. The
+mean of this normal log probability density is modelled as the
+solution of an ODE. The ODE itself depends on some parameters $p$
+which are a subset of $\theta$. The ODE is given as initial value
+problem
 
 \begin{align}
 \dot{y} &= f(y,t,p) (\#eq:odeDef) \\
  y(t_0) &= y^{(0)}. (\#eq:odeInitial)
 \end{align}
 
-The ODE has $N$ states, $y=(y_1, \ldots, y_N)$, and is
-parameterized in terms of parameters $p$ which are a subset of
-$\theta$. Let's now further assume for simplicity that the function
-$l$ only depends on the solution of the ODE at the time-point
-$T$. During the reverse sweep of reverse mode autodiff we are then
-given the autodiff adjoints of $a_{l,y_n}$ wrt to the output state
-$y(T,p)$. These
-are the partials of $l$ wrt to each state
+The ODE has $N$ states, $y=(y_1, \ldots, y_N)$. During the reverse
+sweep of reverse mode autodiff we are then given the autodiff adjoints
+of $a_{l,y_n}$ wrt to the output state $y(T,p)$. These are the
+partials of $l$ wrt to each state
 
 $$ a_{l,y_n} = \left.\frac{\partial l}{\partial y_n}\right|_{t=T} $$
 
@@ -268,12 +268,17 @@ The arguments are:
 hand side. The types ```T1, T2, ...``` can be any type, but they must match
 the types of the matching arguments of ```f```.
 
-In addition a function version is made available which mimics the
-existing ode interface for tolerances. This version will allow users
-to quickly try out the new adjoint interface. **The extra control
-parameters will be set based on best guesses as of now and are subject
-to change**:
-
+In addition a simpler function version which mimics the existing ode
+interface for tolerances should be made available once more experience
+has been gained with the new ODE adjoint method. While at the current
+stage it is premature to make such a simpler interface available, the
+simpler interface is intended to let users quickly try out the new
+adjoint interface. **As it is currently not clear how the extra
+control parameters will be set based the function signature will not
+be made available in the Stan language in the first version of the
+adjoint ODE solver**. Nontheless, once sufficient experience has been
+gained with the adjoint ODE method the following signature should be
+made available:
 
 ```stan
 vector[] ode_adjoint_tol(F f,
@@ -303,12 +308,19 @@ The best guesses based on preliminary experiments for the remaining
 tuning parameters are then set as
 
 - same relative tolerance in all problems
-- `abs_tol_f = abs_tol / 100`
-- `abs_tol_b = abs_tol / 10`
+- `abs_tol_f = abs_tol / 10`
+- `abs_tol_b = abs_tol / 3`
 - `abs_tol_q = abs_tol`
 - $250$ steps between checkpoints
 - bdf solver for forward and backward solve
 - hermite polynomial method for forward function approximation
+
+The above best guesses are only based on early experiments and will
+need to be refined. This design doc intentionally does not define when
+"sufficient" experience has been collected until the simplified
+function can be made available. However, the above defaults (or an
+updated set) should be included in the documentation of the adjoint
+ODE solver.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -14,10 +14,10 @@ implement in Stan the so-called forward-mode ODE method in order to
 obtain in addition to the solution of the ODE the sensitivities of the
 ODE. The cost of this method scales as 
 
-$$ N \cdot M . $$
+$$ N \cdot (M + 1). $$
 
-The computational cost of the adjoint method is much more favorable
-in comparison which is
+The computational cost of the adjoint method scales much more
+favorable in comparison which is
 
 $$ 2 \cdot N + M .$$
 
@@ -25,8 +25,12 @@ The advantage of the adjoint methods shows in particular whenever the
 number of parameters are relatively large in comparison to the number
 of states. Most importantly, the computational cost grows only
 linearly in the number of states and parameters (while forward grows
-exponentially). Thus, this method can scale to much larger problems
-without exponentially increasing computational cost.
+multiplicatively). Thus, this method can scale to much larger problems
+without a multiplicative increasing computational cost. However, the
+adjoint method is more involved resulting in a bigger overhead than
+the forward mode method. As a result, the forward method can
+have advantages for smaller ODE systems and as such both methods
+remain valuable within Stan.
 
 # Motivation
 [motivation]: #motivation
@@ -302,14 +306,16 @@ full Jacobian to some extent.
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
-There is no other analytical technique available which scales in a
-comparable way. Hence, larger ODE problems ( many parameters and/or
-states) are currently out of scope for Stan and the adjoint technique
-does enable Stan to cope with these larger systems.
+There is no other analytical ODE solving technique available which scales in a
+comparable way. The better scalability of the adjoint method enables
+at a fixed computational ressource the possibility to solve larger ODE
+systems with many parameters and/or states to be solved faster. Thus,
+a Stan modeler can increase the complexity of an ODE model under study
+without subtantially increasing model runtimes.
 
-The numerical complexities are rather involved as 3 nested
-integrations are performed. This makes things somewhat fragile and
-less robust. What makes the backward integration in
+The numerical complexities of the adjoint method are rather involved
+as 3 nested integrations are performed. This makes things somewhat
+fragile and less robust. What makes the backward integration in
 particular involved is that the solution of the forward problem must
 be stored as a continuous function in memory and hence an
 interpolation of the forward solve is required. This is provided by
@@ -320,11 +326,13 @@ and heavy to craft on our own.
 # Prior art
 [prior-art]: #prior-art
 
-The adjoint sensitivity method is not very widley used. It's somewhat
-present in engineering literature and found it's way into packages
-like `DifferentialEquations.jl` in Julia. Another noticeable reference
-is [FATODE](https://www.mcs.anl.gov/~hongzh/publication/zhang-2014/SISC_FATODE_final.pdf)
-and a [discourse post from Ben](https://discourse.mc-stan.org/t/on-adjoint-sensitivity-of-ode-pde/5148/16).
+The adjoint sensitivity method is applied in within different domains
+of science. For example the method is present in engineering
+literature and found it's way into packages like
+`DifferentialEquations.jl` in Julia. Another noticeable reference is
+[FATODE](https://www.mcs.anl.gov/~hongzh/publication/zhang-2014/SISC_FATODE_final.pdf)
+and a [discourse post from
+Ben](https://discourse.mc-stan.org/t/on-adjoint-sensitivity-of-ode-pde/5148/16).
 
 Another domain where the adjoint sensitivity method is beind used is
 in systems biology. The [AMICI](https://github.com/AMICI-dev/AMICI)
@@ -335,9 +343,11 @@ benchmarked on various problems from systems biology as
 [published](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005331)
 (see also [this arxiv pre-print](https://arxiv.org/abs/2012.09122)).
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
+However, so far the adjoint method is commonly build into special
+purpose software as the method requires a fixed target
+functional. The integration of the adjoint ODE sensitivity method into
+a general puropse autodiff library as Stan math is presumably the
+first implementation of its kind.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -6,13 +6,13 @@
 # Summary
 [summary]: #summary
 
-Ordinary differential equations (ODEs) are currently severely costly to
-fit in Stan for larger systems. This is due to the multiplicative
+Ordinary differential equations (ODEs) are currently expensive to
+evaluate in Stan for larger systems. This is due to the multiplicative
 scaling of the required computing resources with the ODE system size
 $N$ and the number of parameters $M$ defining the ODE. Currently we
-implement in Stan the so-called forward-mode ODE method in order to
-obtain in addition to the solution of the ODE the sensitivities of the
-ODE. The cost of this method scales as 
+implement in Stan the forward-mode (direct) sensitivity ODE method in
+order to obtain in addition to the solution of the ODE the
+sensitivities of the ODE. The cost of this method scales as
 
 $$ N \cdot (M + 1). $$
 
@@ -41,9 +41,9 @@ them gets large, the computational cost explode quickly. With the
 adjoint ODE solving method Stan will be able to scale to much larger
 problems involving more states and more parameters. Examples are large
 pharmacokinetic / pharmacodynamic systems or physiological based
-pharmacokinetic models or bigger susceptible infectious & removed
-models. The adjoint ODE method will grow the computational cost only
-linearly with states and parameters and therefore modelers can
+pharmacokinetic models or bigger susceptible, infected, and recovered
+(SIR) models. The adjoint ODE method will grow the computational cost
+only linearly with states and parameters and therefore modelers can
 more freely increase the complexity of the ODE model without
 substantially increasing inference times.
 
@@ -68,8 +68,8 @@ adjoints as defined by the autodiff call graph. This calculation
 involves a backward solve of an adjoint ODE system with $N$ so-called
 ODE adjoint states as defined by the adjoint method and explained
 below. Along the backward integration of the ODE adjoint problem one
-has in addition to solve $M$ one-dimensional quadrature problems (one
-for each parameter of the ODE).
+has in addition to solve $M$ one-dimensional quadrature problems which
+depend on the adjoint states (one problem for each parameter of the ODE).
 
 The numerical complexity is higher for the ODE adjoint method in
 comparison to the forward method. While most of the complexity is

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -230,13 +230,13 @@ The proposed function should have the following signature:
 vector[] ode_adjoint_tol_ctl(F f,
     vector y0,
     real t0, real[] times,
-    real relative_tolerance_forward, vector abs_tol_f,
-    real rel_tol_b, vector abs_tol_b,
-    real rel_tol_q, real abs_tol_q,
+    real relative_tolerance_forward, vector absolute_tolerance_forward,
+    real relative_tolerance_backward, vector absolute_tolerance_backward,
+    real relative_tolerance_quadrature, real absolute_tolerance_quadrature,
     int max_num_steps,
     int num_steps_between_checkpoints,
     int interpolation_polynomial,
-    int solver_f, int solver_b
+    int solver_forward, int solver_backward
     T1 arg1, T2 arg2, ...)
 ```
 
@@ -247,12 +247,12 @@ The arguments are:
 4. ```times``` - Sorted arary of times to which the ode will be solved (each
   element must be greater than t0)  
 5. ```relative_tolerance_forward``` - Relative tolerance for forward solve (data)  
-6. ```abs_tol_f``` - Absolute tolerance vector for each state for
+6. ```absolute_tolerance_forward``` - Absolute tolerance vector for each state for
    forward solve (data)  
-7. ```rel_tol_b``` - Relative tolerance for backward solve (data)  
-8. ```abs_tol_b``` - Absolute tolerance vector for each state backward solve (data)  
-9. ```rel_tol_q``` - Relative tolerance for backward quadrature (data)  
-10. ```abs_tol_q``` - Absolute tolerance for backward quadrature (data)  
+7. ```relative_tolerance_backward``` - Relative tolerance for backward solve (data)  
+8. ```absolute_tolerance_backward``` - Absolute tolerance vector for each state backward solve (data)  
+9. ```relative_tolerance_quadrature``` - Relative tolerance for backward quadrature (data)  
+10. ```absolute_tolerance_quadrature``` - Absolute tolerance for backward quadrature (data)  
 11. ```max_num_steps``` - Maximum number of time-steps to take in integrating
   the ODE solution between output time points for forward and backward
   solve (data)  
@@ -260,9 +260,9 @@ The arguments are:
     solution (data)  
 13. ```interpolation_polynomial``` can be 1 for hermite or 2 for
     polynomial interpolation method of CVODES  
-14. ```solver_f``` solver used for forward ODE problem: 1=Adams,
+14. ```solver_forward``` solver used for forward ODE problem: 1=Adams,
     2=bdf  
-15. ```solver_b``` solver used for backward ODE problem: 1=Adams,
+15. ```solver_backward``` solver used for backward ODE problem: 1=Adams,
     2=bdf  
 16. ```arg1, arg2, ...``` - Arguments passed unmodified to the ODE right
 hand side. The types ```T1, T2, ...``` can be any type, but they must match
@@ -284,7 +284,7 @@ made available:
 vector[] ode_adjoint_tol(F f,
     vector y0,
     real t0, real[] times,
-    real rel_tol, real abs_tol,
+    real relative_tolerance, real absolute_tolerance,
     int max_num_steps,
     T1 arg1, T2 arg2, ...)
 ```
@@ -295,8 +295,8 @@ The arguments are:
 3. ```t0``` - Initial time of the ode solve  
 4. ```times``` - Sorted array of times to which the ode will be solved (each
   element must be greater than t0)  
-5. ```rel_tol``` - Relative tolerance for all solves (data)  
-6. ```abs_tol``` - Absolute tolerance for all solves (data)  
+5. ```relative_tolerance``` - Relative tolerance for all solves (data)  
+6. ```absolute_tolerance``` - Absolute tolerance for all solves (data)  
 7. ```max_num_steps``` - Maximum number of time-steps to take in integrating
   the ODE solution between output time points for forward and backward
   solve (data)  
@@ -308,9 +308,9 @@ The best guesses based on preliminary experiments for the remaining
 tuning parameters are then set as
 
 - same relative tolerance in all problems
-- `abs_tol_f = abs_tol / 10`
-- `abs_tol_b = abs_tol / 3`
-- `abs_tol_q = abs_tol`
+- `absolute_tolerance_forward = absolute_tolerance / 10`
+- `absolute_tolerance_backward = absolute_tolerance / 3`
+- `absolute_tolerance_quadrature = absolute_tolerance`
 - $250$ steps between checkpoints
 - bdf solver for forward and backward solve
 - hermite polynomial method for forward function approximation

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -1,0 +1,156 @@
+- Feature Name: ode-adjoint
+- Start Date: 2021-02-02
+- RFC PR: (leave this empty)
+- Stan Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Ordinary differential equations (ODEs) are currently severly costly to
+fit in Stan for larger systems. This is due to the multiplicative
+scaling of the required computing ressources with the ODE system size
+N and the number of parameters M defining the ODE. Currently we
+implement in Stan the so-called forward-mode ODE method in order to
+obtain in addition to the solution of the ODE the sensitivities of the
+ODE. The cost of this method scales as 
+
+$$ N * M . $$
+
+The computational cost of the adjoint method is much more favorable
+in comparison which is
+
+$$ 2 * N + M .$$
+
+The advantage of the adjoint methods shows in particular whenever the
+number of parameters are relatively large in comparison to the number
+of states. Most importantly, the computational cost grows only
+linearly in the number of states and parameters (while forward grows
+exponentially). Thus, this method can scale to much larger problems
+without exponentially increasing computational cost.
+
+# Motivation
+[motivation]: #motivation
+
+Stan is currently practically limited to solve problems with ODEs
+which are small in the number of states and parameters. If either of
+them gets large, the computational cost explodes quickly. With the
+adjoint ODE solving method Stan will be able to scale to much larger
+problems involving more states and more parameters. Examples are large
+pharmacokinetic / pharmacodynamic systems or physiological based
+pharmacokinetic models or bigger susceptible infectious & removed
+models. As the adjoint ODE method will grow the computational cost
+only linearly with states and parameters, the modelers can more freely
+increase the complexity of the ODE model without having to worry too
+much about infeasible inference times.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+The new solver `ode_adjoint` will follow in it's design the variadic
+ODE functions. As the new solver is numerically more involved (see
+reference level) there are merely more tuning parameters needed for
+the solver. The actual impementation will be provided by the CVODES
+package which we already include in Stan.
+
+From a more internal stan math perspective, the key difference to the
+existing forward mode solvers will be that the gradients are not any
+more precomputed. Instead, during the forward sweep of reverse mode
+autodiff, the ODE is solved first for the N states (without any
+sensitivities). When reverse mode AD then performs the backward sweep,
+the adjoints of the input operands are directly computed given the
+input adjoints. This involves a backward solve in time with N states
+and solving M quadrature problems in addition.
+
+The numerical complexity is higher for the adjoint method in
+comparison to the forward method. While most of the complexity is
+handled by CVODES, the numerical procedure seems to require more
+knowledge about the tuning parameters. At least at the moment it
+appears not possible to make an easy to use interface of this
+functionality available without most tuning parameters. We need to
+first collect some experience before a simpler version can be made
+available (if that is feasible at all). The tuning parameters exposed
+as proposed are:
+
+- absolute & relative tolerance forward solve; absolute tolerance
+  should be a vector of length N, the number of states
+- absolute & relative tolerance backward solve
+- absolute & relative tolerance quadrature problem
+- forward solver: bdf-dense / bdf-iterated / adams - 1 / 2 / 3
+- backward solver: bdf-dense / bdf-iterated / adams - 1 / 2 / 3
+- checkpointing: number of checkpoints every X steps
+- checkpointing: hermite or polynomial approximation - 1 / 2
+
+During an experimental phase of this feature we can hopefully learn
+which of these are relevant and which can be dropped for a final
+release of the `ode_adjoint` function.
+
+**Leaving the template text here for now**
+
+Explain the proposal as if it was already included in the project and you were teaching it to another Stan programmer in the manual. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Stan programmers should *think* about the feature, and how it should impact the way they use the relevant package. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Stan programmers and new Stan programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+Here I would like to document exactly the math of the approach using
+the notation of the CVODES manual.
+
+TODO !!!
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+It's some work to be done. Other than that there are no alternatives
+to my knowledge to get large ODE systems working in Stan. What we are
+missing out for now is to exploit the sparsity structure of the
+ODE. This would allow for more efficient solvers and even larger
+systems, but this is not possible at the moment to figure out
+structurally the inter-dependencies of inputs and outputs.
+
+# TODO: Update the rest
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -236,7 +236,7 @@ vector[] ode_adjoint_tol_ctl(F f,
     int max_num_steps,
     int num_steps_between_checkpoints,
     int interpolation_polynomial,
-    int solver_forward, int solver_backward
+    int solver_forward, int solver_backward,
     T1 arg1, T2 arg2, ...)
 ```
 

--- a/designs/0027-adjoint-ode.md
+++ b/designs/0027-adjoint-ode.md
@@ -290,20 +290,17 @@ and heavy to craft on our own.
 The adjoint sensitivity method is not very widley used. It's somewhat
 present in engineering literature and found it's way into packages
 like `DifferentialEquations.jl` in Julia. Another noticeable reference
-is
-https://www.mcs.anl.gov/~hongzh/publication/zhang-2014/SISC_FATODE_final.pdf
-and a discourse post from Ben
-https://discourse.mc-stan.org/t/on-adjoint-sensitivity-of-ode-pde/5148/16
-.
+is [FATODE](https://www.mcs.anl.gov/~hongzh/publication/zhang-2014/SISC_FATODE_final.pdf)
+and a [discourse post from Ben](https://discourse.mc-stan.org/t/on-adjoint-sensitivity-of-ode-pde/5148/16).
 
 Another domain where the adjoint sensitivity method is beind used is
-in systems biology. The (AMICI)[https://github.com/AMICI-dev/AMICI]
+in systems biology. The [AMICI](https://github.com/AMICI-dev/AMICI)
 toolkit has been build to solve ODE system for large scale systems
 biology equation systems to be used within optimizer software. The
 adjoint method is implemented in AMICI using CVODES and has been
 benchmarked on various problems from systems biology as
-(published)[https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005331]
-(see also (this arxiv pre-print)[https://arxiv.org/abs/2012.09122]).
+[published](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1005331)
+(see also [this arxiv pre-print](https://arxiv.org/abs/2012.09122)).
 
 Discuss prior art, both the good and the bad, in relation to this proposal.
 A few examples of what this can include are:


### PR DESCRIPTION
This PR discusses how the adjoint ODE approach can be integrated with Stan math. The focus of the document is to

- describe the merits of the approach
- how the CVODES user manual notation lines up with Stan math notation
- shows how the CVODES functionality is integrated with the Stan math autodiff library
- proposes a super-set of tuning parameters for the numerical procedures which need to be assessed by the community in order to weed them out somewhat (or not at all)

I am not sure on how to present a rendered version of this. I used this R command to render the text:

```R
rmarkdown::render("0027-adjoint-ode.md", output_format="bookdown::html_document2")
```

Here is a rendered pdf of the document of easier reading: 
[0027-adjoint-ode.pdf](https://github.com/stan-dev/design-docs/files/6064565/0027-adjoint-ode.pdf)

updated version 7. March 2021

[0027-adjoint-ode.pdf](https://github.com/stan-dev/design-docs/files/6097413/0027-adjoint-ode.pdf)

update 23rd March 2021

[0027-adjoint-ode.pdf](https://github.com/stan-dev/design-docs/files/6192512/0027-adjoint-ode.pdf)

update 7th April 2021

[0027-adjoint-ode.pdf](https://github.com/stan-dev/design-docs/files/6274031/0027-adjoint-ode.pdf)

