### PR TITLE
Add a `jacobian` keyword to the Stan language

### DIFF
--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -41,7 +41,7 @@ $$
 \log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J_c\left(y\right)\right)
 $$
 
-The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $ \log(J_c(y))$. 
+The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $\log(J_c(y))$. 
 A variable (unconstraining) transform is a surjective function $f:\mathcal{X} \rightarrow \mathbb{R}^N$ from a constrained subset $\mathcal{X} \subseteq \mathbb{R}^M$ onto the full space $\mathbb{R}^N$.
 The inverse transform $f^{-1}$ maps from the unconstrained space to the constrained space. 
 Let $J$ be the Jacobian of $f^{-1}$ so that $J(x) = (\nabla f^{-1})(x).$ and $|J(x)|$ is its absolute Jacobian determinant. A transform in Stan specifies 

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -30,18 +30,20 @@ constraints {
 data {
  real lb;
  real ub;
+ int N;
 }
 parameters {
  //(2) User defined constraint
- upper_bound<ub=ub> b_raw;
+ real<udc=upper_bound(ub)> b;
+ vector<udc=upper_bound(ub)>[N] b_vec;
  real c_raw;
 }
 transformed parameters {
  // (3) Transform and accumulates like stan math directly
- real b = exp(b_raw) + lb;
+ real c = exp(c_raw) + lb;
  // Underneath the hood, only actually calculated if
  // Jacobian bool template parameter is set to true
- jacobian += b_raw;
+ jacobian += c_raw;
 }
 ```
 
@@ -51,11 +53,11 @@ transformed parameters {
 Given a function mapping $c$ that transforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [2]
 
 $$
-\pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) 
+\pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right))
 $$
 
 $$
-\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right)) 
+\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right))
 $$
 
 In a Stan program, $ \log\left(J(c\left(y\right)\right))$ is handled via the Stan languages defined constraints such as `lower`, `upper`, `ordered`, and others.

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -41,7 +41,8 @@ $$
 \log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J_c\left(y\right)\right)
 $$
 
-The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $ \log\left(J_c(y)\right)$. A variable (unconstraining) transform is a surjective function $f:\mathcal{X} \rightarrow \mathbb{R}^N$ from a constrained subset $\mathcal{X} \subseteq \mathbb{R}^M$ onto the full space $\mathbb{R}^N$.
+The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $ \log(J_c(y))$. 
+A variable (unconstraining) transform is a surjective function $f:\mathcal{X} \rightarrow \mathbb{R}^N$ from a constrained subset $\mathcal{X} \subseteq \mathbb{R}^M$ onto the full space $\mathbb{R}^N$.
 The inverse transform $f^{-1}$ maps from the unconstrained space to the constrained space. 
 Let $J$ be the Jacobian of $f^{-1}$ so that $J(x) = (\nabla f^{-1})(x).$ and $|J(x)|$ is its absolute Jacobian determinant. A transform in Stan specifies 
 
@@ -153,6 +154,18 @@ transformed parameters {
 
 Functions ending in `_jacobian` will operate the same as `_lp` functions, but instead of exposing `target` they will expose `jacobian`.
 
+The generated C++ will reuse a lot of the code from generating the `_lp` functions and will look something like this
+
+```c++
+template <bool Jacobian, typename T1, typename T2, typename TJacobian>
+auto foo(const T1& x, const T2& ub, TJacobian& jacobian__) {
+  if (Jacobian) {
+    jacobian__ += x //...;
+  }
+  return ub - exp(x);
+}
+```
+
 # Drawbacks
 [drawbacks]: #drawbacks
 
@@ -162,6 +175,12 @@ Functions ending in `_jacobian` will operate the same as `_lp` functions, but in
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
+
+- Alternatives
+
+An alternative to this approach would be the `constraints` block as defined in the git history of this proposal's branch. 
+That allows for user defined constraints directly in the parameters block.
+
 
 - What is the impact of not doing this?
 

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -51,8 +51,11 @@ transformed parameters {
 Given a function mapping $c$ that transforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [2]
 
 $$
-\pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) \\
-\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right)) \\
+\pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) 
+$$
+
+$$
+\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right)) 
 $$
 
 In a Stan program, $ \log\left(J(c\left(y\right)\right))$ is handled via the Stan languages defined constraints such as `lower`, `upper`, `ordered`, and others.

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -4,64 +4,61 @@
 # Summary
 [summary]: #summary
 
-Adding a `jacobian` target that increments the log probablity will allow users to impliment their own constraints within stan programs. The `jacobian` target will be accessible directly in `transformed parameters` and implictly in `parameters` through `~ distribution(...)` functions. The below examples shows the main use cases. The parameter `a` is given a `normal(0, 10)` prior, `b_raw` is transformed to have a lower bound of 5, and `c_raw` uses a user defined constraint function to transform `c` to have an upper bound. 
+Adding a `jacobian` target that increments the log probablity will allow users to impliment their own constraints within a stan program. The `jacobian` target will be accessible directly in `transformed parameters` and a new `constraints` block where users can define custom constraints similar to Stan's already existing constrained data types. The below examples shows the main use cases. 
 
 ```stan
-functions {
-  // User defined constrain function
-  // Implicitly passed `jacobian` parameter
-  real upper_bound_constrain(real x, real upper_bound) {
+constraints {
+  upper_bound {
+    real constrain(real x, real upper_bound) {
       jacobian += x;
       return upper_bound - exp(x);
-  }
-  // Must be defined for internal `write_array` function
-  // Not called directly by user
-  real upper_bound_unconstrain(real x, real upper_bound) {
-    return log(upper_bound - x);
+    }
+    real constrain(vector x, real upper_bound) {
+      jacobian += sum(x);
+      return upper_bound - exp(x);
+    }
+    real unconstrain(real x, real upper_bound) {
+      return log(upper_bound - x);
+    }
+    // Used for data
+    int validate(real x, real upper_bound) {
+      // For most this will be 
+      return x < upper_bound;
+    }
   }
 }
 data {
-  real lower_bound;
-  real upper_bound;
+  real lb;
+  real ub;
 }
 parameters {
-  // (1) Declares a and calls 
-  //  target += normal_lpdf(a, 0, 10);
-  real a ~ normal(0, 10);
-  // Maybe we allow this?
-  real x, y, z ~ normal(0, 10);
-  // Allow parameters to be passed into the prior
-  real<lower=0> sigma
-  real mu ~ normal(0, sigma);
-  real b_raw;
+  //(2) User defined constraint
+  upper_bound<ub=ub> b_raw;
   real c_raw;
 }
 transformed parameters {
-  // (2) Transform and accumulates like stan math directly
-  real b = exp(b_raw) + lower_bound;
+  // (3) Transform and accumulates like stan math directly
+  real b = exp(b_raw) + lb;
   // Underneath the hood, only actually calculated if 
   // Jacobian bool template parameter is set to true
   jacobian += b_raw;
-  // (3) jacobian implicitly passed to constrain functions
-  real c = upper_bound_constrain(c_raw, upper_bound);
 }
 ```
-
-I think it would be nice to have at least one of these added to the language
 
 # Motivation
 [motivation]: #motivation
 
-Since the beginning of the Stan language it was decided that users would only be permitted to increment the joint log probability `target` within the model block. This is due to partially to incapsulation concerns. Given a function mapping $c$ that tranforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the transformed log transformed density function [2]
+Since the beginning of the Stan language it was decided that users would only be permitted to increment the joint log probability `target` within the model block. This is partially due to incapsulation concerns. Given a function mapping $c$ that tranforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [2]
 
 $$
 \pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) \\
 \log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right)) \\
 $$
 
-Having the Stan language define types for transform from the constrain to unconstrain space allows users to focus on modeling in the constrained space while algorithm developers could focus on developing in the unconstrained space. This is very nice for both parties since it is both of their preferred spaces to work in.
+In a Stan program, $ \log\left(J(c\left(y\right)\right))$ is handled via the Stan languages defined constraints such as `lower`, `upper`, `ordered`, and others.
+Having the Stan language define types for transforms from the unconstrained to constrained space allows users to focus on modeling in the constrained space while algorithm developers focus on developing algorithms in the unconstrained space. This is very nice for both parties since it is both of their preferred spaces to work in.
 
-However, I disagree with this pure encapsulation of the constrain space for users! I don't think it's bad, in fact 95% of the time this is very good. The main issue is that the strong opinion forces users to write code that is either fully encapsulated or works directly on the unconstrain space. For instance, from the comment [3] by @betanalpha (slightly commented and fleshed out)
+However, I disagree with this pure encapsulation of the constrain space for users! I don't think it's bad, in fact 95% of the time this is very good. The main issue is that the strong opinion forces users to write code that is either fully in the constrained space or works directly on the unconstrain space. For instance, from the comment [3] by @betanalpha (slightly commented and fleshed out)
 
 > It’s only in the context of trying to assign a density on the output value that a Jacobian is needed, so the proper encapsulation is
 
@@ -92,57 +89,165 @@ model {
 }
 ```
 
-I think only having the all hands off approach and a set of given constrain types is kind of paradoxical! The hands off or hands on approach also leaves out a growing group of Stan programmers who write code for other Stan programmers. Right now, adding a constraint to Stan involves having to touch the math library which is rather complicated. Not just by C++ itself, but the essentially small DSL we use to describe autodiff in the Stan math library.
-
-Sometimes users, and particularly Stan programmers, need to cook. I'd like us to be in a place between telling users, "No you are a little baby and this is a wittle baby kitchen for teeny tiny babies like you" and tossing them a propane tank, match box, and pack of cigarettes.
+I think only having all unconstrained approach or a set of given constrain types is kind of paradoxical! The hands off or hands on approach also leaves out a growing group of Stan programmers who write code for other Stan programmers. Right now, adding a constraint to Stan involves having to touch the math library which is rather complicated. Not just by C++ itself, but the essentially small DSL we use to describe autodiff in the Stan math library.
 
 Having a way for users and Stan package writers to define constraints allows users to remove some of the veil of encapsulation and write repeatable code for future models.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the project and you were teaching it to another Stan programmer in the manual. That generally means:
+The following section is a draft of the docs for the new constraint and `jacobian` keyword.
 
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how Stan programmers should *think* about the feature, and how it should impact the way they use the relevant package. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing Stan programmers and new Stan programmers.
+## Constraint Block
 
-For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+### Overview
 
-# Reference-level explanation
-[reference-level-explanation]: #reference-level-explanation
+The constraints block was included in Stan 2.XX, introduced to provide users with the ability to define custom constraints on parameters, transformed parameters, and data. This block is situated immediately after the `functions` block and before the `data` block in a Stan program. The primary purpose of the `constraints` block is to allow users to define custom constraints that can be used in the same way as built-in constraints.
 
-The first thing we would do is add `jacobian` keyword to the Stan language. Like `target`, `jacobian` would only be available on the right hand side of statements to be accumulated into. It's domain is restricted to the `transformed parameters` and `model` block as well as functions ending in `_constrain`.
+### Syntax 
 
-This section will break the model given in the summary section to break down what the Stan compiler requires piece by piece. First, let's look at the `functions` block where we define our constrain and free functions
+A constraints block is defined by the keyword `constraints`. Inside of the `constraints` block each constraint is its own block with a given `constraint_name` and the functions needed to define the constraint. Inside the `constraints` block, users can define one or more constraint types. Each constraint type is encapsulated within its own set of curly braces and is identified by a unique name.
+
+Each user-defined constraint within the constraint block must specify a set of functions that define the transformation between unconstrained and constrained spaces, validate data, and adjust the log probability for the Jacobian of the transformation. The general structure of a user-defined constraint is as follows:
 
 ```stan
-functions {
-  // User defined constrain function
-  // Implicitly passed `jacobian` parameter
-  real upper_bound_constrain(real x, real upper_bound) {
-      jacobian += x;
-      return upper_bound - exp(x);
-  }
-  // Must be defined for internal `write_array` function
-  // Not called directly by user
-  real upper_bound_unconstrain(real x, real upper_bound) {
-    return log(upper_bound - x);
+constraints {
+  constraint_name {
+    // Transform from unconstrained to constrained space
+    ReturnType constrain(TransformType, OtherArgs...) {
+      // ... transformation logic ...
+      // Increment the log probability for the Jacobian
+      jacobian += ...;
+      return ...;
+    }
+
+    // Transform from constrained to unconstrained space
+    type unconstrain(TransformType, OtherArgs...) {
+      // ... inverse transformation logic ...
+      return ...;
+    }
+
+    // Validate data
+    int validate(TransformType, OtherArgs...) {
+      // ... validation logic ...
+      return ...; // typically returns a boolean value
+    }
   }
 }
 ```
 
-The Stan compiler will check that for each `{FUNCTION_NAME}_constrain` function there is an associated `{FUNCTION_NAME}_unconstrain`. The templates and signature for the `_constrain` function will be the same as a normal function except for a `bool` template parameter `Jacobian` and a templated reference argument `jacobian` to accumulate the jacobian determinant into.
+Each constraint type must define a set of functions that govern the transformation and validation of variables subject to the constraint. The first argument for all functions defined in a constraint must be the argument of interest to be transformed or validated. These functions include:
 
-```c++
-template <bool Jacobian, typename T1, typename T2, typename TJacobian>
-return_type_t<T1, T2> upper_bound_constrain(const T1& x, const T2& upper_bound, TJacobian& jacobian);
+- `constrain(TransformType, OtherArguments...) -> ReturnType`: Transforms a real unconstrained variable to a constrained space.
+- `unconstrain(TransformType, OtherArguments...) -> ReturnType`: Transforms a real constrained variable back to the unconstrained space.
+- `validate(TransformType, OtherArguments...) -> ReturnType`: Validates a real variable against the constraint, returning 1 if valid and 0 otherwise.
 
+### Using the jacobian Keyword
+
+The `jacobian` keyword is introduced within the Constraint block to facilitate the increment of the log of the absolute determinant of the Jacobian. This keyword behaves similarly to the `target` keyword, allowing users to increment the log probability to account for the change of variables in the probability density function. The `jacobian` keyword is available in both the `constraints` block and the `transformed parameters` block.
+
+### Declaring Variables with User-defined Constraints
+
+Variables can be declared with user-defined constraints in the data, transformed data, parameters, transformed parameters, and generated quantities blocks. The syntax for declaring a variable with a user-defined constraint is as follows:
+
+```stan
+type<udc=constraint_name(args...)> variable_name;
 ```
 
-The body will be the same as any other Stan function, except that when we detect the left hand side of an accumulate statement is for the keyword `jacobian` we will wrap that jacobian accumulation in an `if (Jacobian)` statement so that it is only accumulated if requested at compile time.
+Here, udc denotes a user-defined constraint , and constraint_name(args...) specifies the name of the constraint along with any arguments it requires. 
+
+
+### Example Usage
+
+```stan
+constraints {
+  upper_bound {
+    real constrain(real x, real upper_bound) {
+      jacobian += x;
+      return upper_bound - exp(x);
+    }
+    real constrain(vector x, real upper_bound) {
+      jacobian += sum(x);
+      return upper_bound - exp(x);
+    }
+    real unconstrain(real x, real upper_bound) {
+      return log(upper_bound - x);
+    }
+    // Used for data
+    int validate(real x, real upper_bound) {
+      // For most this will be 
+      return x < upper_bound;
+    }
+  }
+}
+data {
+  real a;
+  real u_bound;
+  int N;
+}
+
+transformed data {
+  // Data will use the validate() function from the user-defined constraint
+  real<udf=upper_bound(u_bound)> a_validated;
+}
+
+parameters {
+  // User-defined constraint applied to parameters alpha and b
+  real<udf=upper_bound(u_bound)> alpha;
+  vector<udf=upper_bound(u_bound)> b;
+  // In these cases this is the same as calling 
+  // real<upper=u_bound> alpha;
+  // vector<upper=u_bound>[N] b;
+}
+```
+
+In this example, upper_bound is a user-defined constraint that is applied to the data and parameters. The validate() function from upper_bound is used to validate a_validated in the transformed data block, and the transformations defined in upper_bound are applied to alpha and b in the parameters block.
+
+### Error Messages
+
+If the `constrain` function of a constraint does not increment `jacobian` a warning is thrown to inform users. In these cases it is better to use a standard function as a new constraint type is most likely not necessary.
+
+```
+Warning: {CONSTRAINT_TYPE} does not increment the log of the absolute of the determinant of the jacobian. It is recommended to instead use a function in `transformed parameters` instead of a custom constraint.
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The first thing we would do is add `jacobian` keyword to the Stan language. Like `target`, `jacobian` would only be available on the left hand side of statements to be accumulated into. It's domain is restricted to the `transformed parameters` and `constraints` block.
+
+This section will break down the model given in the summary section to show what the Stan compiler requires piece by piece. First, let's look at the `constraints` block where we define our constrain and unconstrain functions
+
+## Constraint Block
+
+```stan
+constraints {
+  upper_bound {
+    constrain(real x, real upper_bound) {
+      jacobian += x;
+      return upper_bound - exp(x);
+    }
+    real unconstrain(real x, real upper_bound) {
+      return log(upper_bound - x);
+    }
+    // Used for data
+    int validate(real x, real upper_bound) {
+      // For most this will be 
+      return x < upper_bound;
+    }
+  }
+}
+```
+
+The new `constraints` block will need to be added to the compiler's parser, validator, mir, and c++ mir. The parser will transpile each of the constraints to c++ functions which start with the name of the constraint. For the example above the signatures would be 
+
+```
+upper_bound_constrain__(...)
+upper_bound_unconstrain__(...)
+upper_bound_validate__(...)
+```
+
+The only function of the three listed above that has rules that differ from standard function generation is the `*_constrain` function which has an additional `jacobian` argument and `Jacobian` template parameter. The jacobian is kept behind an if statement that checks the compile time value `Jacobian` before incrementing the jacobian. Besides the jacobian argument the rest of the function will parse exactly like a standard function.
 
 ```c++
 template <bool Jacobian, typename T1, typename T2, typename TJacobian>
@@ -159,26 +264,10 @@ return_type_t<T1, T2> upper_bound_constrain(const T1& x, const T2& upper_bound,
 
 The `_unconstrain` function will not be used directly by the user and instead will be used internally in the Stan model class when we need to go from the constrained to unconstrained space. The code generation for these will be the same as a standard function.
 
-Next is the parameters block.
-
-While optional, I think it would be nice to have a way for users to declare priors directly in the parameters block like so
-```stan
-parameters {
-  // (1) Declares a and calls 
-  //  target += normal_lpdf(a, 0, 10);
-  real a ~ normal(0, 10);
-}
-```
-
-this would be translated to the equivalent of 
-```
-  real a;
-  a ~ normal(0, 10);
-```
-
-Gelman said he would find this useful and I agree I like how it keeps everything close by. Often times I'm declaring a parameter then just giving it normal priors in the model block. This would save a bit of code and I think looks nice / makes since. Whether we want to allow `real x, y, z ~ normal(0, 10);` can be a point of discussion. Again I think it reduces reduntant code and is nice to read. Though I could also see it being abused.
+## Transformed Parameters 
 
 Inside of transformed parameters we expose `jacobian` like in the functions section listed below. Any jacobian accumulation will be wrapped in an `if (Jacobian)`
+
 ```stan
 parameters {
   real b_raw;
@@ -192,75 +281,32 @@ transformed parameters {
 }
 ```
 
-```stan
-parameters {
-  real c_raw;
-}
-transformed parameters {
-  // (3) jacobian implicitly passed to constrain functions
-  real c = upper_bound_constrain(c_raw, upper_bound);
-}
-```
-
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 - Making a new keyword `jacobian` will almost surely break current user code.
 
-Why should we *not* do this?
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 - Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
+
+I think the other alternative is to not have a new block and have users define `*_constrain`, `*_unconstrain`, and `*_validate` functions in the `functions` block. This might be easier to implement, but personally I don't think this looks very nice.
+
 - What is the impact of not doing this?
 
-```stan
-parameters {
-  // Acts like ~ function where param injected as first argument
-  real<udc=lower_bound(lb)> a;
-}
-```
-
-```stan
-types {
-  lower_bound {
-    constrain(real x) {
-      // ...
-    }
-    unconstrain(real x) {
-      // ...
-    }
-  };
-}
-```
-
-# Prior art
-[prior-art]: #prior-art
-
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For language, library, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
-
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+Users will have to write programs as they currently do, where jacobian accumulations happen directly in transformed parameters or within the model block.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+- Is there a better syntax for users than 
 
+```stan
+vector<udc=my_constrain(args...)> X;
+```
 
 # Citations
 

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -31,23 +31,23 @@ transformed paramters {
 # Motivation
 [motivation]: #motivation
 
-Given a function $c$ mapping unconstrained parameters in $Y$ to constrained parameters in $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [1]
+Given a function $c$ mapping unconstrained parameters in $Y$ to constrained parameters in $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $|J_c(y)|$, Stan calculates the log transformed density function [1]
 
 $$
-\pi^*(y) = \pi\left( c\left(y\right) \right) J_c\left(y\right)
+\pi^*(y) = \pi\left( c\left(y\right) \right) |J_c\left(y\right)|
 $$
 
 $$
-\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J_c\left(y\right)\right)
+\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(|J_c\left(y\right)\right|)
 $$
 
-The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $\log(J_c(y))$. 
+The Stan languages has built in constraints constraints such as `lower`, `upper`, `ordered`, etc. to handle $\log(|J_c(y)|)$. 
 A variable (unconstraining) transform is a surjective function $f:\mathcal{X} \rightarrow \mathbb{R}^N$ from a constrained subset $\mathcal{X} \subseteq \mathbb{R}^M$ onto the full space $\mathbb{R}^N$.
 The inverse transform $f^{-1}$ maps from the unconstrained space to the constrained space. 
 Let $J$ be the Jacobian of $f^{-1}$ so that $J(x) = (\nabla f^{-1})(x).$ and $|J(x)|$ is its absolute Jacobian determinant. A transform in Stan specifies 
 
 - $f(y)$ The unconstraining transform
-- $f^{-1}\left(y\right)$ The inverse unconstraining transform
+- $f^{-1}\left(y\right)$ The constraining transform
 - $\log |J(y)|$ The log absolute Jacobian determinant function for $f^{-1}$ chosen such that the resulting distribution over the constrained variables is uniform
 - $V(y)$ that tests that $x \in \mathcal{X}$ (i.e., that $x$ satisfies the constraint defining $\mathcal{X}$).
 

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -4,51 +4,51 @@
 # Summary
 [summary]: #summary
 
-Adding a `jacobian` target that increments the log probablity will allow users to impliment their own constraints within a stan program. The `jacobian` target will be accessible directly in `transformed parameters` and a new `constraints` block where users can define custom constraints similar to Stan's already existing constrained data types. The below examples shows the main use cases. 
+Adding a `jacobian` target that increments the log of the absolute value of the determinant of the Jacobian will allow users to implement their own constraints within a stan program. The `jacobian` target will be accessible directly in `transformed parameters` and a new `constraints` block where users can define custom constraints similar to Stan's already existing constrained data types. The below examples show the main use cases.
 
 ```stan
 constraints {
-  upper_bound {
-    real constrain(real x, real upper_bound) {
-      jacobian += x;
-      return upper_bound - exp(x);
-    }
-    real constrain(vector x, real upper_bound) {
-      jacobian += sum(x);
-      return upper_bound - exp(x);
-    }
-    real unconstrain(real x, real upper_bound) {
-      return log(upper_bound - x);
-    }
-    // Used for data
-    int validate(real x, real upper_bound) {
-      // For most this will be 
-      return x < upper_bound;
-    }
-  }
+ upper_bound {
+   real constrain(real x, real upper_bound) {
+     jacobian += x;
+     return upper_bound - exp(x);
+   }
+   real constrain(vector x, real upper_bound) {
+     jacobian += sum(x);
+     return upper_bound - exp(x);
+   }
+   real unconstrain(real x, real upper_bound) {
+     return log(upper_bound - x);
+   }
+   // Used for data
+   int validate(real x, real upper_bound) {
+     // For most this will be
+     return x < upper_bound;
+   }
+ }
 }
 data {
-  real lb;
-  real ub;
+ real lb;
+ real ub;
 }
 parameters {
-  //(2) User defined constraint
-  upper_bound<ub=ub> b_raw;
-  real c_raw;
+ //(2) User defined constraint
+ upper_bound<ub=ub> b_raw;
+ real c_raw;
 }
 transformed parameters {
-  // (3) Transform and accumulates like stan math directly
-  real b = exp(b_raw) + lb;
-  // Underneath the hood, only actually calculated if 
-  // Jacobian bool template parameter is set to true
-  jacobian += b_raw;
+ // (3) Transform and accumulates like stan math directly
+ real b = exp(b_raw) + lb;
+ // Underneath the hood, only actually calculated if
+ // Jacobian bool template parameter is set to true
+ jacobian += b_raw;
 }
 ```
 
 # Motivation
 [motivation]: #motivation
 
-Since the beginning of the Stan language it was decided that users would only be permitted to increment the joint log probability `target` within the model block. This is partially due to incapsulation concerns. Given a function mapping $c$ that tranforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [2]
+Given a function mapping $c$ that transforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the log transformed density function [2]
 
 $$
 \pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) \\
@@ -58,40 +58,39 @@ $$
 In a Stan program, $ \log\left(J(c\left(y\right)\right))$ is handled via the Stan languages defined constraints such as `lower`, `upper`, `ordered`, and others.
 Having the Stan language define types for transforms from the unconstrained to constrained space allows users to focus on modeling in the constrained space while algorithm developers focus on developing algorithms in the unconstrained space. This is very nice for both parties since it is both of their preferred spaces to work in.
 
-However, I disagree with this pure encapsulation of the constrain space for users! I don't think it's bad, in fact 95% of the time this is very good. The main issue is that the strong opinion forces users to write code that is either fully in the constrained space or works directly on the unconstrain space. For instance, from the comment [3] by @betanalpha (slightly commented and fleshed out)
+Most of the time this encapsulation is very good. The main issue is that the strong opinion forces users to write code that is either fully in the constrained space or works directly on the unconstrained space. For instance, from a comment [3] by @betanalpha (slightly commented and fleshed out)
 
 > It’s only in the context of trying to assign a density on the output value that a Jacobian is needed, so the proper encapsulation is
 
-
 ```stan
 functions {
-  real f(real x) {
-    // transform function
-  }
-  real jacobian(real x) {
-    // jacobian determinant calculation
-  }
-  real prob(real x) {
-    // lpdf calculation
-  }
+ real f(real x) {
+   // transform function
+ }
+ real jacobian(real x) {
+   // jacobian determinant calculation
+ }
+ real prob(real x) {
+   // lpdf calculation
+ }
 }
 parameters {
-  real theta;
+ real theta;
 }
 transformed parameters {
-  real eta = f(theta);
+ real eta = f(theta);
 }
 model {
-  // In a pure sense, neither line is well defined on it's 
-  //  own, but the combination are well defined.
-  eta ~ prob(values);     
-  target += jacobian(theta); 
+ // In a pure sense, neither line is well defined on it's
+ //  own, but the combinations are well defined.
+ eta ~ prob(values);
+ target += jacobian(theta);
 }
 ```
 
-I think only having all unconstrained approach or a set of given constrain types is kind of paradoxical! The hands off or hands on approach also leaves out a growing group of Stan programmers who write code for other Stan programmers. Right now, adding a constraint to Stan involves having to touch the math library which is rather complicated. Not just by C++ itself, but the essentially small DSL we use to describe autodiff in the Stan math library.
+So users have to choose between either leaving the nice constrained space to write your model in the unconstrained space or to restrict the models developed on constrained spaces to just the ones available with the Stan languages constrained types. The hands off or hands on approach also leaves out a growing group of Stan programmers who write code for other Stan programmers. In addition, adding a constraint to Stan involves having to touch the math library which is rather complicated. Not just by C++ itself, but the essentially small DSL we use to describe autodiff in the Stan math library.
 
-Having a way for users and Stan package writers to define constraints allows users to remove some of the veil of encapsulation and write repeatable code for future models.
+Having a new block for user-defined constraints allows users and developers to remove some of the veil of encapsulation and write repeatable code for future models.
 
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
@@ -104,35 +103,37 @@ The following section is a draft of the docs for the new constraint and `jacobia
 
 The constraints block was included in Stan 2.XX, introduced to provide users with the ability to define custom constraints on parameters, transformed parameters, and data. This block is situated immediately after the `functions` block and before the `data` block in a Stan program. The primary purpose of the `constraints` block is to allow users to define custom constraints that can be used in the same way as built-in constraints.
 
-### Syntax 
+### Syntax
 
 A constraints block is defined by the keyword `constraints`. Inside of the `constraints` block each constraint is its own block with a given `constraint_name` and the functions needed to define the constraint. Inside the `constraints` block, users can define one or more constraint types. Each constraint type is encapsulated within its own set of curly braces and is identified by a unique name.
 
-Each user-defined constraint within the constraint block must specify a set of functions that define the transformation between unconstrained and constrained spaces, validate data, and adjust the log probability for the Jacobian of the transformation. The general structure of a user-defined constraint is as follows:
+Each user-defined constraint within the constraint block must specify a set of functions that define the transformation between unconstrained and constrained spaces, validate data, and increment the log of the absolute value of the determinant of the Jacobian. The general structure of a user-defined constraint is as follows:
 
 ```stan
 constraints {
-  constraint_name {
-    // Transform from unconstrained to constrained space
-    ReturnType constrain(TransformType, OtherArgs...) {
-      // ... transformation logic ...
-      // Increment the log probability for the Jacobian
-      jacobian += ...;
-      return ...;
-    }
+ constraint_name {
+   // Transform from unconstrained to constrained space
+   ReturnType constrain(TransformType, OtherArgs...) {
+     // ... transformation logic ...
+     // Increment Jacobian
+     jacobian += ...;
+     return ...;
+   }
 
-    // Transform from constrained to unconstrained space
-    type unconstrain(TransformType, OtherArgs...) {
-      // ... inverse transformation logic ...
-      return ...;
-    }
 
-    // Validate data
-    int validate(TransformType, OtherArgs...) {
-      // ... validation logic ...
-      return ...; // typically returns a boolean value
-    }
-  }
+   // Transform from constrained to unconstrained space
+   type unconstrain(TransformType, OtherArgs...) {
+     // ... inverse transformation logic ...
+     return ...;
+   }
+
+
+   // Validate data
+   int validate(TransformType, OtherArgs...) {
+     // ... validation logic ...
+     return ...; // typically returns a boolean value
+   }
+ }
 }
 ```
 
@@ -144,7 +145,7 @@ Each constraint type must define a set of functions that govern the transformati
 
 ### Using the jacobian Keyword
 
-The `jacobian` keyword is introduced within the Constraint block to facilitate the increment of the log of the absolute determinant of the Jacobian. This keyword behaves similarly to the `target` keyword, allowing users to increment the log probability to account for the change of variables in the probability density function. The `jacobian` keyword is available in both the `constraints` block and the `transformed parameters` block.
+The `jacobian` keyword is introduced within the Constraint block to facilitate the increment of the log of the absolute determinant of the Jacobian. This keyword behaves similarly to the `target` keyword, allowing users to account for the change of variables in the probability density function. The `jacobian` keyword is available in both the `constraints` block and the `transformed parameters` block.
 
 ### Declaring Variables with User-defined Constraints
 
@@ -154,50 +155,51 @@ Variables can be declared with user-defined constraints in the data, transformed
 type<udc=constraint_name(args...)> variable_name;
 ```
 
-Here, udc denotes a user-defined constraint , and constraint_name(args...) specifies the name of the constraint along with any arguments it requires. 
-
+Here, udc denotes a user-defined constraint , and constraint_name(args...) specifies the name of the constraint along with any arguments it requires.
 
 ### Example Usage
 
 ```stan
 constraints {
-  upper_bound {
-    real constrain(real x, real upper_bound) {
-      jacobian += x;
-      return upper_bound - exp(x);
-    }
-    real constrain(vector x, real upper_bound) {
-      jacobian += sum(x);
-      return upper_bound - exp(x);
-    }
-    real unconstrain(real x, real upper_bound) {
-      return log(upper_bound - x);
-    }
-    // Used for data
-    int validate(real x, real upper_bound) {
-      // For most this will be 
-      return x < upper_bound;
-    }
-  }
+ upper_bound {
+   real constrain(real x, real upper_bound) {
+     jacobian += x;
+     return upper_bound - exp(x);
+   }
+   real constrain(vector x, real upper_bound) {
+     jacobian += sum(x);
+     return upper_bound - exp(x);
+   }
+   real unconstrain(real x, real upper_bound) {
+     return log(upper_bound - x);
+   }
+   // Used for data
+   int validate(real x, real upper_bound) {
+     // For most this will be
+     return x < upper_bound;
+   }
+ }
 }
 data {
-  real a;
-  real u_bound;
-  int N;
+ real a;
+ real u_bound;
+ int N;
 }
+
 
 transformed data {
-  // Data will use the validate() function from the user-defined constraint
-  real<udf=upper_bound(u_bound)> a_validated;
+ // Data will use the validate() function from the user-defined constraint
+ real<udf=upper_bound(u_bound)> a_validated;
 }
 
+
 parameters {
-  // User-defined constraint applied to parameters alpha and b
-  real<udf=upper_bound(u_bound)> alpha;
-  vector<udf=upper_bound(u_bound)> b;
-  // In these cases this is the same as calling 
-  // real<upper=u_bound> alpha;
-  // vector<upper=u_bound>[N] b;
+ // User-defined constraint applied to parameters alpha and b
+ real<udf=upper_bound(u_bound)> alpha;
+ vector<udf=upper_bound(u_bound)> b;
+ // In these cases this is the same as calling
+ // real<upper=u_bound> alpha;
+ // vector<upper=u_bound>[N] b;
 }
 ```
 
@@ -207,14 +209,15 @@ In this example, upper_bound is a user-defined constraint that is applied to the
 
 If the `constrain` function of a constraint does not increment `jacobian` a warning is thrown to inform users. In these cases it is better to use a standard function as a new constraint type is most likely not necessary.
 
-```
-Warning: {CONSTRAINT_TYPE} does not increment the log of the absolute of the determinant of the jacobian. It is recommended to instead use a function in `transformed parameters` instead of a custom constraint.
+```md
+Warning: {CONSTRAINT_TYPE} does not increment the log of the absolute of the determinant of the jacobian.
+It is recommended to instead use a function in `transformed parameters` instead of a custom constraint.
 ```
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The first thing we would do is add `jacobian` keyword to the Stan language. Like `target`, `jacobian` would only be available on the left hand side of statements to be accumulated into. It's domain is restricted to the `transformed parameters` and `constraints` block.
+The first thing we would do is add the `jacobian` keyword to the Stan language. Like `target`, `jacobian` would only be available on the left hand side of statements to be accumulated into. Its domain is restricted to the `transformed parameters` and `constraints` block.
 
 This section will break down the model given in the summary section to show what the Stan compiler requires piece by piece. First, let's look at the `constraints` block where we define our constrain and unconstrain functions
 
@@ -222,26 +225,26 @@ This section will break down the model given in the summary section to show what
 
 ```stan
 constraints {
-  upper_bound {
-    constrain(real x, real upper_bound) {
-      jacobian += x;
-      return upper_bound - exp(x);
-    }
-    real unconstrain(real x, real upper_bound) {
-      return log(upper_bound - x);
-    }
-    // Used for data
-    int validate(real x, real upper_bound) {
-      // For most this will be 
-      return x < upper_bound;
-    }
-  }
+ upper_bound {
+   constrain(real x, real upper_bound) {
+     jacobian += x;
+     return upper_bound - exp(x);
+   }
+   real unconstrain(real x, real upper_bound) {
+     return log(upper_bound - x);
+   }
+   // Used for data
+   int validate(real x, real upper_bound) {
+     // For most this will be
+     return x < upper_bound;
+   }
+ }
 }
 ```
 
-The new `constraints` block will need to be added to the compiler's parser, validator, mir, and c++ mir. The parser will transpile each of the constraints to c++ functions which start with the name of the constraint. For the example above the signatures would be 
+The new `constraints` block will need to be added to the compiler's parser, validator, mir, and c++ mir. The parser will transpile each of the constraints to c++ functions which start with the name of the constraint. For the example above the signatures would be
 
-```
+```c++
 upper_bound_constrain__(...)
 upper_bound_unconstrain__(...)
 upper_bound_validate__(...)
@@ -252,48 +255,46 @@ The only function of the three listed above that has rules that differ from stan
 ```c++
 template <bool Jacobian, typename T1, typename T2, typename TJacobian>
 return_type_t<T1, T2> upper_bound_constrain(const T1& x, const T2& upper_bound,
-   TJacobian& jacobian) {
-  if (Jacobian) {
-    // If x is a vector we can
-    //  wrap the right hand side in a sum()
-    jacobian += x;
-  }
-  return subtract(upper_bound, exp(x));
+  TJacobian& jacobian) {
+ if (Jacobian) {
+   // If x is a vector we can
+   //  wrap the right hand side in a sum()
+   jacobian += x;
+ }
+ return subtract(upper_bound, exp(x));
 }
 ```
 
 The `_unconstrain` function will not be used directly by the user and instead will be used internally in the Stan model class when we need to go from the constrained to unconstrained space. The code generation for these will be the same as a standard function.
 
-## Transformed Parameters 
+## Transformed Parameters
 
-Inside of transformed parameters we expose `jacobian` like in the functions section listed below. Any jacobian accumulation will be wrapped in an `if (Jacobian)`
+Inside of transformed parameters we expose `jacobian` like in the functions section listed below. Any jacobian accumulation will be wrapped in an `if (Jacobian)` so that the Jacobian increment only happens when requested.
 
 ```stan
 parameters {
-  real b_raw;
+ real b_raw;
 }
 transformed parameters {
-  // (2) Transform and accumulates like stan math directly
-  real b = exp(b_raw) + lower_bound;
-  // Underneath the hood, only actually calculated if 
-  // Jacobian bool template parameter is set to true
-  jacobian += b_raw;
+ // (2) Transform and accumulates like stan math directly
+ real b = exp(b_raw) + lower_bound;
+ // Underneath the hood, only actually calculated if
+ // Jacobian bool template parameter is set to true
+ jacobian += b_raw;
 }
 ```
-
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 - Making a new keyword `jacobian` will almost surely break current user code.
 
-
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 - Why is this design the best in the space of possible designs?
 
-I think the other alternative is to not have a new block and have users define `*_constrain`, `*_unconstrain`, and `*_validate` functions in the `functions` block. This might be easier to implement, but personally I don't think this looks very nice.
+The other alternative is to not have a new block and have users define `*_constrain`, `*_unconstrain`, and `*_validate` functions in the `functions` block. This might be easier to implement, but it is not as nice looking as a new constraints block.
 
 - What is the impact of not doing this?
 
@@ -302,7 +303,7 @@ Users will have to write programs as they currently do, where jacobian accumulat
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- Is there a better syntax for users than 
+- Is there a better syntax for users than
 
 ```stan
 vector<udc=my_constrain(args...)> X;

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -4,7 +4,7 @@
 # Summary
 [summary]: #summary
 
-Adding a `jacobian` target that increments the log of the absolute value of the determinant of the Jacobian will allow users to implement their own constraints within a stan program. The `jacobian` target will be accessible directly in `transformed parameters` and a new `constraints` block where users can define custom constraints similar to Stan's already existing constrained data types. The below examples show the main use cases.
+This design doc proposes adding a `jacobian` target and a new block for user defined constraints. The `jacobian` target will be accessible directly in `transformed parameters` and a new `constraints` block where users can define custom constraints similar to Stan's already existing constrained data types. The below examples shows an example use case.
 
 ```stan
 constraints {

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -194,14 +194,14 @@ data {
 
 transformed data {
  // Data will use the validate() function from the user-defined constraint
- real<udf=upper_bound(u_bound)> a_validated;
+ real<udc=upper_bound(u_bound)> a_validated;
 }
 
 
 parameters {
  // User-defined constraint applied to parameters alpha and b
- real<udf=upper_bound(u_bound)> alpha;
- vector<udf=upper_bound(u_bound)> b;
+ real<udc=upper_bound(u_bound)> alpha;
+ vector<udc=upper_bound(u_bound)> b;
  // In these cases this is the same as calling
  // real<upper=u_bound> alpha;
  // vector<upper=u_bound>[N] b;

--- a/designs/0034-jacobian.md
+++ b/designs/0034-jacobian.md
@@ -1,0 +1,268 @@
+- Feature Name: `jacobian` target
+- Start Date: 01-25-2024
+
+# Summary
+[summary]: #summary
+
+Adding a `jacobian` target that increments the log probablity will allow users to impliment their own constraints within stan programs. The `jacobian` target will be accessible directly in `transformed parameters` and implictly in `parameters` through `~ distribution(...)` functions. The below examples shows the main use cases. The parameter `a` is given a `normal(0, 10)` prior, `b_raw` is transformed to have a lower bound of 5, and `c_raw` uses a user defined constraint function to transform `c` to have an upper bound. 
+
+```stan
+functions {
+  // User defined constrain function
+  // Implicitly passed `jacobian` parameter
+  real upper_bound_constrain(real x, real upper_bound) {
+      jacobian += x;
+      return upper_bound - exp(x);
+  }
+  // Must be defined for internal `write_array` function
+  // Not called directly by user
+  real upper_bound_unconstrain(real x, real upper_bound) {
+    return log(upper_bound - x);
+  }
+}
+data {
+  real lower_bound;
+  real upper_bound;
+}
+parameters {
+  // (1) Declares a and calls 
+  //  target += normal_lpdf(a, 0, 10);
+  real a ~ normal(0, 10);
+  // Maybe we allow this?
+  real x, y, z ~ normal(0, 10);
+  // Allow parameters to be passed into the prior
+  real<lower=0> sigma
+  real mu ~ normal(0, sigma);
+  real b_raw;
+  real c_raw;
+}
+transformed parameters {
+  // (2) Transform and accumulates like stan math directly
+  real b = exp(b_raw) + lower_bound;
+  // Underneath the hood, only actually calculated if 
+  // Jacobian bool template parameter is set to true
+  jacobian += b_raw;
+  // (3) jacobian implicitly passed to constrain functions
+  real c = upper_bound_constrain(c_raw, upper_bound);
+}
+```
+
+I think it would be nice to have at least one of these added to the language
+
+# Motivation
+[motivation]: #motivation
+
+Since the beginning of the Stan language it was decided that users would only be permitted to increment the joint log probability `target` within the model block. This is due to partially to incapsulation concerns. Given a function mapping $c$ that tranforms a set of parameters from the unconstrained space $Y$ to the constrained space $X$, probability density function $\pi$, and a Jacobian determinant function over the constrained space $J(c(y))$, Stan calculates the transformed log transformed density function [2]
+
+$$
+\pi^*(y) = \pi\left( c\left(y\right) \right) J(c\left(y\right)) \\
+\log\left(\pi^*(y)\right) = \log\left(\pi\left( c\left(y\right) \right)\right) + \log\left(J(c\left(y\right)\right)) \\
+$$
+
+Having the Stan language define types for transform from the constrain to unconstrain space allows users to focus on modeling in the constrained space while algorithm developers could focus on developing in the unconstrained space. This is very nice for both parties since it is both of their preferred spaces to work in.
+
+However, I disagree with this pure encapsulation of the constrain space for users! I don't think it's bad, in fact 95% of the time this is very good. The main issue is that the strong opinion forces users to write code that is either fully encapsulated or works directly on the unconstrain space. For instance, from the comment [3] by @betanalpha (slightly commented and fleshed out)
+
+> It’s only in the context of trying to assign a density on the output value that a Jacobian is needed, so the proper encapsulation is
+
+
+```stan
+functions {
+  real f(real x) {
+    // transform function
+  }
+  real jacobian(real x) {
+    // jacobian determinant calculation
+  }
+  real prob(real x) {
+    // lpdf calculation
+  }
+}
+parameters {
+  real theta;
+}
+transformed parameters {
+  real eta = f(theta);
+}
+model {
+  // In a pure sense, neither line is well defined on it's 
+  //  own, but the combination are well defined.
+  eta ~ prob(values);     
+  target += jacobian(theta); 
+}
+```
+
+I think only having the all hands off approach and a set of given constrain types is kind of paradoxical! The hands off or hands on approach also leaves out a growing group of Stan programmers who write code for other Stan programmers. Right now, adding a constraint to Stan involves having to touch the math library which is rather complicated. Not just by C++ itself, but the essentially small DSL we use to describe autodiff in the Stan math library.
+
+Sometimes users, and particularly Stan programmers, need to cook. I'd like us to be in a place between telling users, "No you are a little baby and this is a wittle baby kitchen for teeny tiny babies like you" and tossing them a propane tank, match box, and pack of cigarettes.
+
+Having a way for users and Stan package writers to define constraints allows users to remove some of the veil of encapsulation and write repeatable code for future models.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+Explain the proposal as if it was already included in the project and you were teaching it to another Stan programmer in the manual. That generally means:
+
+- Introducing new named concepts.
+- Explaining the feature largely in terms of examples.
+- Explaining how Stan programmers should *think* about the feature, and how it should impact the way they use the relevant package. It should explain the impact as concretely as possible.
+- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
+- If applicable, describe the differences between teaching this to existing Stan programmers and new Stan programmers.
+
+For implementation-oriented RFCs (e.g. for compiler internals), this section should focus on how compiler contributors should think about the change, and give examples of its concrete impact. For policy RFCs, this section should provide an example-driven introduction to the policy, and explain its impact in concrete terms.
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+The first thing we would do is add `jacobian` keyword to the Stan language. Like `target`, `jacobian` would only be available on the right hand side of statements to be accumulated into. It's domain is restricted to the `transformed parameters` and `model` block as well as functions ending in `_constrain`.
+
+This section will break the model given in the summary section to break down what the Stan compiler requires piece by piece. First, let's look at the `functions` block where we define our constrain and free functions
+
+```stan
+functions {
+  // User defined constrain function
+  // Implicitly passed `jacobian` parameter
+  real upper_bound_constrain(real x, real upper_bound) {
+      jacobian += x;
+      return upper_bound - exp(x);
+  }
+  // Must be defined for internal `write_array` function
+  // Not called directly by user
+  real upper_bound_unconstrain(real x, real upper_bound) {
+    return log(upper_bound - x);
+  }
+}
+```
+
+The Stan compiler will check that for each `{FUNCTION_NAME}_constrain` function there is an associated `{FUNCTION_NAME}_unconstrain`. The templates and signature for the `_constrain` function will be the same as a normal function except for a `bool` template parameter `Jacobian` and a templated reference argument `jacobian` to accumulate the jacobian determinant into.
+
+```c++
+template <bool Jacobian, typename T1, typename T2, typename TJacobian>
+return_type_t<T1, T2> upper_bound_constrain(const T1& x, const T2& upper_bound, TJacobian& jacobian);
+
+```
+
+The body will be the same as any other Stan function, except that when we detect the left hand side of an accumulate statement is for the keyword `jacobian` we will wrap that jacobian accumulation in an `if (Jacobian)` statement so that it is only accumulated if requested at compile time.
+
+```c++
+template <bool Jacobian, typename T1, typename T2, typename TJacobian>
+return_type_t<T1, T2> upper_bound_constrain(const T1& x, const T2& upper_bound,
+   TJacobian& jacobian) {
+  if (Jacobian) {
+    // If x is a vector we can
+    //  wrap the right hand side in a sum()
+    jacobian += x;
+  }
+  return subtract(upper_bound, exp(x));
+}
+```
+
+The `_unconstrain` function will not be used directly by the user and instead will be used internally in the Stan model class when we need to go from the constrained to unconstrained space. The code generation for these will be the same as a standard function.
+
+Next is the parameters block.
+
+While optional, I think it would be nice to have a way for users to declare priors directly in the parameters block like so
+```stan
+parameters {
+  // (1) Declares a and calls 
+  //  target += normal_lpdf(a, 0, 10);
+  real a ~ normal(0, 10);
+}
+```
+
+this would be translated to the equivalent of 
+```
+  real a;
+  a ~ normal(0, 10);
+```
+
+Gelman said he would find this useful and I agree I like how it keeps everything close by. Often times I'm declaring a parameter then just giving it normal priors in the model block. This would save a bit of code and I think looks nice / makes since. Whether we want to allow `real x, y, z ~ normal(0, 10);` can be a point of discussion. Again I think it reduces reduntant code and is nice to read. Though I could also see it being abused.
+
+Inside of transformed parameters we expose `jacobian` like in the functions section listed below. Any jacobian accumulation will be wrapped in an `if (Jacobian)`
+```stan
+parameters {
+  real b_raw;
+}
+transformed parameters {
+  // (2) Transform and accumulates like stan math directly
+  real b = exp(b_raw) + lower_bound;
+  // Underneath the hood, only actually calculated if 
+  // Jacobian bool template parameter is set to true
+  jacobian += b_raw;
+}
+```
+
+```stan
+parameters {
+  real c_raw;
+}
+transformed parameters {
+  // (3) jacobian implicitly passed to constrain functions
+  real c = upper_bound_constrain(c_raw, upper_bound);
+}
+```
+
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+- Making a new keyword `jacobian` will almost surely break current user code.
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+```stan
+parameters {
+  // Acts like ~ function where param injected as first argument
+  real<udc=lower_bound(lb)> a;
+}
+```
+
+```stan
+types {
+  lower_bound {
+    constrain(real x) {
+      // ...
+    }
+    unconstrain(real x) {
+      // ...
+    }
+  };
+}
+```
+
+# Prior art
+[prior-art]: #prior-art
+
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
+
+- For language, library, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
+- For community proposals: Is this done by some other community and what were their experiences with it?
+- For other teams: What lessons can we learn from what other communities have done here?
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+
+This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
+If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
+
+Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
+Please also take into consideration that rust sometimes intentionally diverges from common language features.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
+
+
+# Citations
+
+[1] https://github.com/stan-dev/stanc3/issues/979#issuecomment-956355020
+[2] https://github.com/stan-dev/stanc3/issues/979#issuecomment-932382499


### PR DESCRIPTION
Proposes adding a  `jacobian` keyword and a new `constraints` block to the Stan language

Rendered Version Here:
https://github.com/stan-dev/design-docs/blob/feature/jacobian/designs/0034-jacobian.md