### PR TITLE
Introduction of an AI-policy for stan-dev repos

### DIFF
--- a/ai_policy/AI_policy.md
+++ b/ai_policy/AI_policy.md
@@ -1,23 +1,44 @@
 # AI Contribution Policy
 
-We welcome AI-assisted contributions. This policy exists to ensure that all contributions remain the work of an accountable human contributor and that our community has the transparency it needs to collaborate effectively.
+We welcome AI-assisted contributions. This policy exists to ensure that all
+contributions remain the work of an accountable human contributor and that our
+community has the transparency it needs to collaborate effectively.
 
 ## Human Accountability
 
-Every pull request (PR) must be submitted by a named individual who assumes full responsibility for the contribution. While we recognize that automation and AI can be part of a modern workflow, we do not accept fully automated or agentic submissions.
+Every pull request (PR) must be submitted by a named individual who assumes full
+responsibility for the contribution. While we recognize that automation and AI
+can be part of a modern workflow, we do not accept fully automated or agentic
+submissions.
 
 ## Licensing and Copyright
 
-Every contributor must agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org) within the GitHub PR template. This certifies that each contributor has the right to submit the code under the project's open-source license. This applies regardless of how the code was produced. It is the contributor's responsibility to ensure that any AI-assisted output is compatible with the project's license and that they hold or have cleared the rights to submit it.
+Every contributor must agree to the
+[Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
+within the GitHub PR template. This certifies that each contributor has the
+right to submit the code under the project's open-source license. This applies
+regardless of how the code was produced. It is the contributor's responsibility
+to ensure that any AI-assisted output is compatible with the project's license
+and that they hold or have cleared the rights to submit it.
 
 ## Mandatory AI Use Disclosure
-To maintain transparency and trust within our community, contributors are required to disclose whether AI tools were used in preparing their contribution. We included a corresponding mandatory section in the GitHub PR template. If AI tools were used, the contributor additionally affirms that they have reviewed every change, fully understand the logic and security implications, and are prepared to explain or defend the technical decisions therein during the review process.
+To maintain transparency and trust within our community, contributors are
+required to disclose whether AI tools were used in preparing their contribution.
+We included a corresponding mandatory section in the GitHub PR template. If AI
+tools were used, the contributor additionally affirms that they have reviewed
+every change, fully understand the logic and security implications, and are
+prepared to explain or defend the technical decisions therein during the review
+process.
 
 ### Acknowledgement
-This policy was inspired by the [CloudNativePG AI Policy](https://github.com/cloudnative-pg/governance/blob/main/AI_POLICY.md) and developed with the practical guidance and support of [NumFOCUS](https://numfocus.org) in creating the initial draft. In the spirit of transparency and the "Disclosure" section of this policy, an initial draft of this document was generated using Google Gemini and was subsequently reviewed, edited, and approved by the Stan maintainers.
+This policy was inspired by the
+[CloudNativePG AI Policy](https://github.com/cloudnative-pg/governance/blob/main/AI_POLICY.md)
+and developed with the practical guidance and support of
+[NumFOCUS](https://numfocus.org) in creating the initial draft.
 
 ---
 
-This policy is effective as of [date]. It will be reviewed periodically as AI tools and community norms evolve.
+This policy is effective as of [date].
 
-Questions or suggestions? Join the discussion in our [community channel](https://discourse.mc-stan.org).
+Questions or suggestions? Join the discussion in our
+[community channel](https://discourse.mc-stan.org).

--- a/ai_policy/AI_policy.md
+++ b/ai_policy/AI_policy.md
@@ -1,0 +1,23 @@
+# AI Contribution Policy
+
+We welcome AI-assisted contributions. This policy exists to ensure that all contributions remain the work of an accountable human contributor and that our community has the transparency it needs to collaborate effectively.
+
+## Human Accountability
+
+Every pull request (PR) must be submitted by a named individual who assumes full responsibility for the contribution. While we recognize that automation and AI can be part of a modern workflow, we do not accept fully automated or agentic submissions.
+
+## Licensing and Copyright
+
+Every contributor must agree to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org) within the GitHub PR template. This certifies that each contributor has the right to submit the code under the project's open-source license. This applies regardless of how the code was produced. It is the contributor's responsibility to ensure that any AI-assisted output is compatible with the project's license and that they hold or have cleared the rights to submit it.
+
+## Mandatory AI Use Disclosure
+To maintain transparency and trust within our community, contributors are required to disclose whether AI tools were used in preparing their contribution. We included a corresponding mandatory section in the GitHub PR template. If AI tools were used, the contributor additionally affirms that they have reviewed every change, fully understand the logic and security implications, and are prepared to explain or defend the technical decisions therein during the review process.
+
+### Acknowledgement
+This policy was inspired by the [CloudNativePG AI Policy](https://github.com/cloudnative-pg/governance/blob/main/AI_POLICY.md) and developed with the practical guidance and support of [NumFOCUS](https://numfocus.org) in creating the initial draft. In the spirit of transparency and the "Disclosure" section of this policy, an initial draft of this document was generated using Google Gemini and was subsequently reviewed, edited, and approved by the Stan maintainers.
+
+---
+
+This policy is effective as of [date]. It will be reviewed periodically as AI tools and community norms evolve.
+
+Questions or suggestions? Join the discussion in our [community channel](https://discourse.mc-stan.org).

--- a/ai_policy/AI_policy.md
+++ b/ai_policy/AI_policy.md
@@ -6,8 +6,8 @@ community has the transparency it needs to collaborate effectively.
 
 ## Human Accountability
 
-Every pull request (PR) must be submitted by a named individual who assumes full
-responsibility for the contribution. While we recognize that automation and AI
+Every pull request (PR) must be submitted by a named individual who is 
+responsible for the contribution. While we recognize that automation and AI
 can be part of a modern workflow, we do not accept fully automated or agentic
 submissions.
 
@@ -25,10 +25,9 @@ and that they hold or have cleared the rights to submit it.
 To maintain transparency and trust within our community, contributors are
 required to disclose whether AI tools were used in preparing their contribution.
 We included a corresponding mandatory section in the GitHub PR template. If AI
-tools were used, the contributor additionally affirms that they have reviewed
-every change, fully understand the logic and security implications, and are
-prepared to explain or defend the technical decisions therein during the review
-process.
+tools were used, the contributor additionally affirms that they have reviewed 
+and understood the code, and can explain and defend their changes during the 
+review process.
 
 ### Acknowledgement
 This policy was inspired by the
@@ -38,7 +37,7 @@ and developed with the practical guidance and support of
 
 ---
 
-This policy is effective as of [date].
+This policy is effective as of May 2026.
 
 Questions or suggestions? Join the discussion in our
 [community channel](https://discourse.mc-stan.org).

--- a/ai_policy/PULL_REQUEST_TEMPLATE.md
+++ b/ai_policy/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,75 @@
+# Pull Request
+
+> 💡
+> **Does your PR contain only a trivial change?**
+> 
+> If your PR consists of minor updates, such as fixing a typo, updating a link,
+> or making small documentation tweaks, you can use our **[Lightweight PR Template](?template=trivial-pr.md)** to save time.
+>
+> (Note: Switch to Preview mode to click the link. It will redirect you to open a new PR using the shorter template.)
+
+## Compliance & AI Disclosure
+> This section is mandatory. Do not delete this section. PRs that leave it blank will not be reviewed.
+
+- [ ] I have read the [Contributing Guidelines](../blob/main/.github/CONTRIBUTING.md).
+- [ ] I accept the [Developer Certificate of Origin](https://developercertificate.org).
+- [ ] I have read and comply with the [AI Contribution Policy](../blob/main/AI_policy.md).
+
+**AI Tool Usage Disclosure:**
+*Did you use AI tools (e.g. GitHub Copilot, ChatGPT, Claude, Cursor, etc.) for this PR?*
+
+- [ ] **No AI used.** This PR consists entirely of my own original work.
+- [ ] **AI-Assisted (Minor).** AI was used for boilerplate, syntax, or autocomplete.
+- [ ] **AI-Generated (Major).** AI generated significant logic or entire sections.
+
+> **Note:** If AI was used, I affirm that I have reviewed every line, fully understand the logic and security implications, and am prepared to explain or defend the technical decisions therein during the review process.
+
+## Pre-Review Checklist
+> Please ensure these steps are completed before requesting a review.
+
+- [ ] **Coordination:** For non-trivial changes, an issue was opened and approved by a maintainer. (Link: #____)
+- [ ] **Alignment:** The PR delivers the specific result agreed upon in the linked issue.
+- [ ] **Sync:** Branch is up-to-date with `main` / `develop`.
+- [ ] **Quality:** All existing tests pass locally, and I have added new tests for my changes.
+- [ ] **Docs:** Documentation (README, inline comments, or changelogs) has been updated.
+- [ ] **Notebooks:** If applicable, all `.qmd` / `.Rmd` files render end-to-end in a clean environment without machine-specific paths.
+---
+
+## Summary
+
+<!-- Why is this change needed? What problem does it solve? (1-3 sentences.) -->
+
+Closes # <!-- issue number -->
+
+### Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change (requires behaviour change/migration)
+- [ ] Refactoring (no functional change)
+- [ ] Documentation / Tooling / CI
+
+## What Changed
+
+<!--
+  Describe the technical changes in enough detail for a reviewer to understand
+  the approach without reading every line of code.
+  Tip: if you cannot explain a section without re-reading AI output, that section
+  needs more review before this PR is ready.
+-->
+
+-
+-
+-
+
+## Expected Result
+
+<!--
+  Describe concretely what "done" looks like for this PR.
+  This should match what was agreed upon in the linked issue.
+  Include screenshots, logs, or demo output where helpful.
+-->
+
+**Additional Context**
+
+<!-- Links to design docs, related PRs, Slack discussions, etc. -->

--- a/ai_policy/PULL_REQUEST_TEMPLATE.md
+++ b/ai_policy/PULL_REQUEST_TEMPLATE.md
@@ -2,41 +2,52 @@
 
 > 💡
 > **Does your PR contain only a trivial change?**
-> 
-> If your PR consists of minor updates, such as fixing a typo, updating a link,
-> or making small documentation tweaks, you can use our **[Lightweight PR Template](?template=trivial-pr.md)** to save time.
 >
-> (Note: Switch to Preview mode to click the link. It will redirect you to open a new PR using the shorter template.)
+> If your PR consists of minor updates, such as fixing a typo, updating a link,
+> or making small documentation tweaks, you can use our
+**[Lightweight PR Template](?template=trivial-pr.md)** to save time.
+>
+> (Note: Switch to Preview mode to click the link. You can do so by selecting
+the **Preview** tab at the top of this window. Clicking the link will open a new
+PR using the shorter template.)
 
 ## Compliance & AI Disclosure
-> This section is mandatory. Do not delete this section. PRs that leave it blank will not be reviewed.
+<!--
+  This section is mandatory. Do not delete this section. PRs that leave it blank
+  will not be reviewed.
+-->
 
 - [ ] I have read the [Contributing Guidelines](../blob/main/.github/CONTRIBUTING.md).
 - [ ] I accept the [Developer Certificate of Origin](https://developercertificate.org).
-- [ ] I have read and comply with the [AI Contribution Policy](../blob/main/AI_policy.md).
+- [ ] I have read and comply with the [AI Contribution Policy (0.0.1)](../blob/main/AI_policy.md).
 
 **AI Tool Usage Disclosure:**
-*Did you use AI tools (e.g. GitHub Copilot, ChatGPT, Claude, Cursor, etc.) for this PR?*
+*Did you use AI tools (e.g., GitHub Copilot, ChatGPT, Claude, Cursor, etc.) for
+this PR?*
 
 - [ ] **No AI used.** This PR consists entirely of my own original work.
-- [ ] **AI-Assisted (Minor).** AI was used for boilerplate, syntax, or autocomplete.
-- [ ] **AI-Generated (Major).** AI generated significant logic or entire sections.
-
-> **Note:** If AI was used, I affirm that I have reviewed every line, fully understand the logic and security implications, and am prepared to explain or defend the technical decisions therein during the review process.
+- [ ] **AI-Assisted (Minor).** AI was used for boilerplate, syntax, or
+autocomplete.
+- [ ] **AI-Generated (Major).** AI generated significant logic or entire
+sections.
 
 ## Pre-Review Checklist
-> Please ensure these steps are completed before requesting a review.
+<!-- Please ensure these steps are completed before requesting a review. -->
 
-- [ ] **Coordination:** For non-trivial changes, an issue was opened and approved by a maintainer. (Link: #____)
-- [ ] **Alignment:** The PR delivers the specific result agreed upon in the linked issue.
-- [ ] **Sync:** Branch is up-to-date with `main` / `develop`.
-- [ ] **Quality:** All existing tests pass locally, and I have added new tests for my changes.
-- [ ] **Docs:** Documentation (README, inline comments, or changelogs) has been updated.
-- [ ] **Notebooks:** If applicable, all `.qmd` / `.Rmd` files render end-to-end in a clean environment without machine-specific paths.
+- [ ] **Coordination:** For non-trivial changes, an issue was opened and
+approved by a maintainer. (Link: #____)
+- [ ] **Alignment:** The PR delivers the specific result agreed upon in the
+linked issue.
+- [ ] **Sync:** Branch is up to date with `main` or `master` / `develop`.
+- [ ] **Quality:** All existing tests pass locally. New tests have been added to
+cover my changes (if applicable).
+- [ ] **Change log:** `News.md` has been updated.
+- [ ] **Docs:** Function documentation has been updated.
+- [ ] **Notebooks:** All `.qmd` / `.Rmd` files render end-to-end in a clean
+environment without machine-specific paths (if applicable).
 ---
 
 ## Summary
-
 <!-- Why is this change needed? What problem does it solve? (1-3 sentences.) -->
 
 Closes # <!-- issue number -->
@@ -45,17 +56,16 @@ Closes # <!-- issue number -->
 
 - [ ] Bug fix
 - [ ] New feature
-- [ ] Breaking change (requires behaviour change/migration)
+- [ ] Breaking change (requires a major version bump; strongly discouraged
+without prior discussion)
 - [ ] Refactoring (no functional change)
-- [ ] Documentation / Tooling / CI
+- [ ] Documentation
+- [ ] Build / Dependencies / Configuration / CI
 
 ## What Changed
-
 <!--
   Describe the technical changes in enough detail for a reviewer to understand
   the approach without reading every line of code.
-  Tip: if you cannot explain a section without re-reading AI output, that section
-  needs more review before this PR is ready.
 -->
 
 -
@@ -63,7 +73,6 @@ Closes # <!-- issue number -->
 -
 
 ## Expected Result
-
 <!--
   Describe concretely what "done" looks like for this PR.
   This should match what was agreed upon in the linked issue.
@@ -72,4 +81,7 @@ Closes # <!-- issue number -->
 
 **Additional Context**
 
-<!-- Links to design docs, related PRs, Slack discussions, etc. -->
+<!--
+  Links to design docs, related PRs, or other relevant resources.
+  Use stable links that will remain accessible over time.
+-->


### PR DESCRIPTION
## Description
This pull request introduces an initial proposal of an AI contribution policy that addresses the use of Large Language Models (LLMs) and generative AI tools in code contributions. The policy is designed to be adopted across Stan GitHub packages in the future. Given the growing use of AI-assisted tools, the goal is to provide clear guidance for our contributors.

This PR includes two documents:

+ an AI policy document (`ai_policy.md`)
+ a PR template document that builds upon the AI policy document

We invite the community to review the drafts, share ideas and feedback, and provide input before we test the documents in a selected repository. Thank you.

## TODOs

+ [x] Add AI policy as new page in Stan's Wiki (https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy)
+ [x] Add a link to the AI policy page in the "Home" Wiki page under the section "Contributing new functions and algorithms" (https://github.com/stan-dev/stan/wiki#contributing-new-functions-and-algorithms)
+ [x] Add information about AI policy on Stan's website (see [stan-dev.github.io PR#228](https://github.com/stan-dev/stan-dev.github.io/pull/228))
+ [x] Create PRs for all relevant repos in stan-dev to include link + note to the AI policy (see [Comment below](https://github.com/stan-dev/design-docs/pull/59#issuecomment-4418499436))
+ [ ] Try out new PR template in loo, bayesplot, or posterior